### PR TITLE
Improve error reporting

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,6 +10,7 @@
             "src/lock.cpp",
             "src/message.cpp",
             "src/thread.cpp",
+            "src/status.cpp",
             "src/worker/worker_thread.cpp"
         ],
         "include_dirs": [

--- a/lib/index.js
+++ b/lib/index.js
@@ -77,5 +77,9 @@ module.exports = {
         resolve(new NativeWatcher(channel))
       }, eventMapper)
     })
+  },
+
+  status: function () {
+    return watcher.status()
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@atom/watcher",
   "version": "0.0.1",
   "description": "Atom filesystem watcher",
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
     "lint": "standard",
     "build:debug": "node-gyp rebuild --debug",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "ci:appveyor": "npm run mocha -- --fgrep ^windows --invert --reporter mocha-appveyor-reporter --reporter-options appveyorBatchSize=5",
     "ci:circle": "npm run mocha -- --fgrep '^mac' --invert --reporter mocha-junit-reporter --reporter-options mochaFile=${CIRCLE_TEST_REPORTS}/mocha/test-results.xml",
     "ci:travis": "npm run mocha -- --fgrep '^linux' --invert --reporter list",
-    "aw:test": "clear && npm run build:debug && clear && npm run mocha"
+    "aw:test": "clear && npm run build:debug && clear && npm run mocha",
+    "clean:fixture": "rm -r test/fixture/*.log test/fixture/watched-*"
   },
   "keywords": [
     "filewatch",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build:debug": "node-gyp rebuild --debug",
     "build:verbose": "node-gyp rebuild --verbose",
     "mocha": "mocha --require test/global.js --harmony",
+    "mocha:lldb": "lldb -- node --harmony ./node_modules/.bin/_mocha --require test/global.js",
     "test": "npm run lint && npm run mocha",
     "ci:appveyor": "npm run mocha -- --fgrep ^windows --invert --reporter mocha-appveyor-reporter --reporter-options appveyorBatchSize=5",
     "ci:circle": "npm run mocha -- --fgrep '^mac' --invert --reporter mocha-junit-reporter --reporter-options mochaFile=${CIRCLE_TEST_REPORTS}/mocha/test-results.xml",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "standard",
     "build:debug": "node-gyp rebuild --debug",
+    "build:verbose": "node-gyp rebuild --verbose",
     "mocha": "mocha --require test/global.js --harmony",
     "test": "npm run lint && npm run mocha",
     "ci:appveyor": "npm run mocha -- --fgrep ^windows --invert --reporter mocha-appveyor-reporter --reporter-options appveyorBatchSize=5",

--- a/src/errable.cpp
+++ b/src/errable.cpp
@@ -3,6 +3,7 @@
 #include <uv.h>
 
 #include "errable.h"
+#include "lock.h"
 
 using std::string;
 using std::move;
@@ -23,16 +24,59 @@ void Errable::report_error(string &&message)
   this->message = move(message);
 }
 
-bool Errable::report_uv_error(int errCode)
+bool Errable::report_uv_error(int err_code)
 {
-  if (!errCode) {
+  if (!err_code) {
     return false;
   }
 
-  report_error(uv_strerror(errCode));
+  report_error(uv_strerror(err_code));
   return true;
 }
 
 string Errable::get_error() {
   return message;
+}
+
+SyncErrable::SyncErrable() : Errable()
+{
+  int err = uv_rwlock_init(&rwlock);
+
+  if (err) {
+    Errable::report_error(uv_strerror(err));
+    lock_healthy = false;
+  } else {
+    lock_healthy = true;
+  }
+}
+
+SyncErrable::~SyncErrable()
+{
+  uv_rwlock_destroy(&rwlock);
+}
+
+bool SyncErrable::is_healthy()
+{
+  if (!lock_healthy) {
+    return false;
+  }
+
+  ReadLock lock(rwlock);
+  return Errable::is_healthy();
+}
+
+void SyncErrable::report_error(string &&message)
+{
+  if (!lock_healthy) return;
+
+  WriteLock lock(rwlock);
+  Errable::report_error(move(message));
+}
+
+string SyncErrable::get_error()
+{
+  if (!lock_healthy) return Errable::get_error();
+
+  ReadLock lock(rwlock);
+  return Errable::get_error();
 }

--- a/src/errable.cpp
+++ b/src/errable.cpp
@@ -1,14 +1,20 @@
 #include <string>
 #include <utility>
+#include <sstream>
+#include <iostream>
 #include <uv.h>
 
 #include "errable.h"
 #include "lock.h"
 
+using std::ostream;
 using std::string;
 using std::move;
 
-Errable::Errable() : healthy{true}, message{"ok"}
+Errable::Errable(string source) :
+  healthy{true},
+  source{source},
+  message{"ok"}
 {
   //
 }
@@ -24,21 +30,16 @@ void Errable::report_error(string &&message)
   this->message = move(message);
 }
 
-bool Errable::report_uv_error(int err_code)
+void Errable::report_uv_error(int err_code)
 {
-  if (!err_code) {
-    return false;
-  }
-
   report_error(uv_strerror(err_code));
-  return true;
 }
 
 string Errable::get_error() {
   return message;
 }
 
-SyncErrable::SyncErrable() : Errable()
+SyncErrable::SyncErrable(string source) : Errable(source)
 {
   int err = uv_rwlock_init(&rwlock);
 

--- a/src/errable.h
+++ b/src/errable.h
@@ -2,6 +2,7 @@
 #define ERRABLE_H
 
 #include <string>
+#include <uv.h>
 
 // Superclass for resources that can potentially enter an errored state.
 //
@@ -18,14 +19,28 @@ class Errable {
 public:
   Errable();
 
-  bool is_healthy();
-  void report_error(std::string &&message);
-  bool report_uv_error(int errCode);
-  std::string get_error();
+  virtual bool is_healthy();
+  virtual void report_error(std::string &&message);
+  bool report_uv_error(int err_code);
+  virtual std::string get_error();
 
 private:
   bool healthy;
   std::string message;
+};
+
+// Thread-safe superclass for resources that can enter an errored state.
+class SyncErrable : public Errable {
+public:
+  SyncErrable();
+  ~SyncErrable();
+
+  bool is_healthy() override;
+  void report_error(std::string &&message) override;
+  std::string get_error() override;
+private:
+  bool lock_healthy;
+  uv_rwlock_t rwlock;
 };
 
 #endif

--- a/src/errable.h
+++ b/src/errable.h
@@ -32,7 +32,7 @@ public:
   // Generate a Result from the current error status of this resource. If it has entered an error state,
   // an errored Result will be created with its error message. Otherwise, an ok Result will be regurned.
   template < class V = void* >
-  Result<V> &&health_err_result()
+  Result<V> health_err_result()
   {
     std::string m = get_error();
     return Result<V>::make_error(std::move(m));

--- a/src/lock.cpp
+++ b/src/lock.cpp
@@ -12,3 +12,25 @@ Lock::~Lock()
 {
   uv_mutex_unlock(&mutex);
 }
+
+ReadLock::ReadLock(uv_rwlock_t &rwlock)
+  : rwlock{rwlock}
+{
+  uv_rwlock_rdlock(&rwlock);
+}
+
+ReadLock::~ReadLock()
+{
+  uv_rwlock_rdunlock(&rwlock);
+}
+
+WriteLock::WriteLock(uv_rwlock_t &rwlock)
+  : rwlock{rwlock}
+{
+  uv_rwlock_wrlock(&rwlock);
+}
+
+WriteLock::~WriteLock()
+{
+  uv_rwlock_wrunlock(&rwlock);
+}

--- a/src/lock.h
+++ b/src/lock.h
@@ -14,4 +14,23 @@ private:
   uv_mutex_t &mutex;
 };
 
+// Hold a read lock on a uv_rwlock_t for the lifetime of this instance.
+class ReadLock {
+public:
+  ReadLock(uv_rwlock_t &rwlock);
+  ~ReadLock();
+
+private:
+  uv_rwlock_t &rwlock;
+};
+
+// Hold a write lock on a uv_rwlock_t for the lifetime of this instance.
+class WriteLock {
+  WriteLock(uv_rwlock_t &rwlock);
+  ~WriteLock();
+
+private:
+  uv_rwlock_t &rwlock;
+};
+
 #endif

--- a/src/lock.h
+++ b/src/lock.h
@@ -26,6 +26,7 @@ private:
 
 // Hold a write lock on a uv_rwlock_t for the lifetime of this instance.
 class WriteLock {
+public:
   WriteLock(uv_rwlock_t &rwlock);
   ~WriteLock();
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -11,6 +11,7 @@ using std::endl;
 using std::ostream;
 using std::ofstream;
 using std::string;
+using std::to_string;
 using std::dec;
 using std::setw;
 
@@ -104,7 +105,7 @@ void Logger::disable()
 string plural(long quantity, const string &singular_form, const string &plural_form)
 {
   string result("");
-  result += quantity;
+  result += to_string(quantity);
   result += " ";
 
   if (quantity == 1) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,10 +112,12 @@ public:
     Result< unique_ptr<vector<Message>> > rr = worker_thread.receive_all();
     if (rr.is_error()) {
       LOGGER << "Unable to fetch pending events from work thread: " << rr << "." << endl;
+      return;
     }
 
     unique_ptr<vector<Message>> &accepted = rr.get_value();
     if (!accepted) {
+      // No events to process.
       return;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 
 #include "log.h"
 #include "queue.h"
+#include "status.h"
 #include "worker/worker_thread.h"
 
 using v8::Local;
@@ -197,6 +198,14 @@ public:
       };
       callback->Call(2, argv);
     }
+  }
+
+  void collect_status(Status &status)
+  {
+    status.pending_callback_count = pending_callbacks.size();
+    status.channel_callback_count = channel_callbacks.size();
+
+    worker_thread.collect_status(status);
   }
 
 private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include "log.h"
 #include "queue.h"
 #include "status.h"
+#include "result.h"
 #include "worker/worker_thread.h"
 
 using v8::Local;
@@ -108,7 +109,12 @@ public:
   {
     Nan::HandleScope scope;
 
-    unique_ptr<vector<Message>> accepted = worker_thread.receive_all();
+    Result< unique_ptr<vector<Message>> > rr = worker_thread.receive_all();
+    if (rr.is_error()) {
+      LOGGER << "Unable to fetch pending events from work thread: " << rr << "." << endl;
+    }
+
+    unique_ptr<vector<Message>> &accepted = rr.get_value();
     if (!accepted) {
       return;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -139,8 +139,14 @@ public:
 
         ChannelID channel_id = ack_message->get_channel_id();
         if (channel_id != NULL_CHANNEL_ID) {
-          Local<Value> argv[] = {Nan::Null(), Nan::New<Number>(channel_id)};
-          callback->Call(2, argv);
+          if (ack_message->was_successful()) {
+            Local<Value> argv[] = {Nan::Null(), Nan::New<Number>(channel_id)};
+            callback->Call(2, argv);
+          } else {
+            Local<Value> err = Nan::Error(ack_message->get_message().c_str());
+            Local<Value> argv[] = {err, Nan::Null()};
+            callback->Call(2, argv);
+          }
         } else {
           callback->Call(0, nullptr);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@ using v8::Value;
 using v8::Object;
 using v8::String;
 using v8::Number;
+using v8::Uint32;
 using v8::Function;
 using v8::FunctionTemplate;
 using v8::Array;
@@ -337,19 +338,71 @@ void unwatch(const Nan::FunctionCallbackInfo<Value> &info)
   instance.unwatch(channel_id, move(ack_callback));
 }
 
+void status(const Nan::FunctionCallbackInfo<Value> &info)
+{
+  Status status;
+  instance.collect_status(status);
+
+  Local<Object> status_object = Nan::New<Object>();
+  Nan::Set(
+    status_object,
+    Nan::New<String>("pendingCallbackCount").ToLocalChecked(),
+    Nan::New<Uint32>(static_cast<uint32_t>(status.pending_callback_count))
+  );
+  Nan::Set(
+    status_object,
+    Nan::New<String>("channelCallbackCount").ToLocalChecked(),
+    Nan::New<Uint32>(static_cast<uint32_t>(status.channel_callback_count))
+  );
+  Nan::Set(
+    status_object,
+    Nan::New<String>("workerThreadOk").ToLocalChecked(),
+    Nan::New<String>(status.worker_thread_ok).ToLocalChecked()
+  );
+  Nan::Set(
+    status_object,
+    Nan::New<String>("workerInSize").ToLocalChecked(),
+    Nan::New<Uint32>(static_cast<uint32_t>(status.worker_in_size))
+  );
+  Nan::Set(
+    status_object,
+    Nan::New<String>("workerInOk").ToLocalChecked(),
+    Nan::New<String>(status.worker_in_ok).ToLocalChecked()
+  );
+  Nan::Set(
+    status_object,
+    Nan::New<String>("workerOutSize").ToLocalChecked(),
+    Nan::New<Uint32>(static_cast<uint32_t>(status.worker_out_size))
+  );
+  Nan::Set(
+    status_object,
+    Nan::New<String>("workerOutOk").ToLocalChecked(),
+    Nan::New<String>(status.worker_out_ok).ToLocalChecked()
+  );
+  info.GetReturnValue().Set(status_object);
+}
+
 void initialize(Local<Object> exports)
 {
-  exports->Set(
+  Nan::Set(
+    exports,
     Nan::New<String>("configure").ToLocalChecked(),
     Nan::GetFunction(Nan::New<FunctionTemplate>(configure)).ToLocalChecked()
   );
-  exports->Set(
+  Nan::Set(
+    exports,
     Nan::New<String>("watch").ToLocalChecked(),
     Nan::GetFunction(Nan::New<FunctionTemplate>(watch)).ToLocalChecked()
   );
-  exports->Set(
+  Nan::Set(
+    exports,
     Nan::New<String>("unwatch").ToLocalChecked(),
     Nan::GetFunction(Nan::New<FunctionTemplate>(unwatch)).ToLocalChecked()
+  );
+  Nan::Set(
+    exports,
+    Nan::New<String>("status").ToLocalChecked(),
+    Nan::GetFunction(Nan::New<FunctionTemplate>(status)).ToLocalChecked()
   );
 }
 

--- a/src/message.h
+++ b/src/message.h
@@ -41,6 +41,10 @@ public:
   FileSystemPayload(FileSystemPayload &&original);
   ~FileSystemPayload() {};
 
+  FileSystemPayload(const FileSystemPayload &original) = delete;
+  FileSystemPayload &operator=(const FileSystemPayload &original) = delete;
+  FileSystemPayload &operator=(FileSystemPayload &&original) = delete;
+
   const ChannelID &get_channel_id() const;
   const FileSystemAction &get_filesystem_action() const;
   const EntryKind &get_entry_kind() const;
@@ -76,6 +80,10 @@ public:
   CommandPayload(CommandPayload &&original);
   ~CommandPayload() {};
 
+  CommandPayload(const CommandPayload &original) = delete;
+  CommandPayload &operator=(const CommandPayload &original) = delete;
+  CommandPayload &operator=(CommandPayload &&original) = delete;
+
   CommandID get_id() const;
   const CommandAction &get_action() const;
   const std::string &get_root() const;
@@ -94,6 +102,10 @@ public:
   AckPayload(const CommandID key, const ChannelID channel_id, bool success, const std::string &&message);
   AckPayload(AckPayload &&original) = default;
   ~AckPayload() {};
+
+  AckPayload(const AckPayload &original) = delete;
+  AckPayload &operator=(const AckPayload &original) = delete;
+  AckPayload &operator=(AckPayload &&original) = delete;
 
   const CommandID &get_key() const;
   const ChannelID &get_channel_id() const;
@@ -121,6 +133,10 @@ public:
   explicit Message(AckPayload &&e);
   Message(Message&& original);
   ~Message();
+
+  Message(const Message&) = delete;
+  Message &operator=(const Message&) = delete;
+  Message &operator=(Message&&) = delete;
 
   const FileSystemPayload* as_filesystem() const;
   const CommandPayload* as_command() const;

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -31,7 +31,7 @@ Queue::~Queue()
   uv_mutex_destroy(&mutex);
 }
 
-Result<> &&Queue::enqueue(Message &&message)
+Result<> Queue::enqueue(Message &&message)
 {
   if (!is_healthy()) return health_err_result();
 
@@ -40,21 +40,21 @@ Result<> &&Queue::enqueue(Message &&message)
   return ok_result();
 }
 
-Result< unique_ptr<vector<Message>> > &&Queue::accept_all()
+Result< unique_ptr<vector<Message>> > Queue::accept_all()
 {
   if (!is_healthy()) return health_err_result< unique_ptr<vector<Message>> >();
 
   Lock lock = {mutex};
 
   if (active->empty()) {
-    unique_ptr<vector<Message>> n = nullptr;
-    return make_ok_result(move(n));
+    unique_ptr<vector<Message>> n;
+    return ok_result(move(n));
   }
 
   unique_ptr<vector<Message>> consumed = move(active);
   active.reset(new vector<Message>);
 
-  return make_ok_result(move(consumed));
+  return ok_result(move(consumed));
 }
 
 size_t Queue::size()

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -1,24 +1,29 @@
 #include <iterator>
 #include <vector>
 #include <utility>
+#include <string>
 #include <uv.h>
 
 #include "queue.h"
 #include "message.h"
 #include "lock.h"
+#include "result.h"
 
 using std::move;
 using std::vector;
 using std::back_inserter;
 using std::copy;
 using std::unique_ptr;
+using std::string;
 
-Queue::Queue() : Errable(), active{new vector<Message>}
+Queue::Queue(string name) : Errable(name), active{new vector<Message>}
 {
   int err;
 
   err = uv_mutex_init(&mutex);
-  report_uv_error(err);
+  if (err) {
+    report_uv_error(err);
+  }
 }
 
 Queue::~Queue()
@@ -26,25 +31,30 @@ Queue::~Queue()
   uv_mutex_destroy(&mutex);
 }
 
-void Queue::enqueue(Message &&message)
+Result<> &&Queue::enqueue(Message &&message)
 {
-  if (!is_healthy()) return;
+  if (!is_healthy()) return health_err_result();
 
   Lock lock(mutex);
   active->push_back(move(message));
+  return ok_result();
 }
 
-unique_ptr<vector<Message>> Queue::accept_all()
+Result< unique_ptr<vector<Message>> > &&Queue::accept_all()
 {
-  if (!is_healthy()) return nullptr;
+  if (!is_healthy()) return health_err_result< unique_ptr<vector<Message>> >();
 
   Lock lock = {mutex};
 
-  if (active->empty()) return nullptr;
+  if (active->empty()) {
+    unique_ptr<vector<Message>> n = nullptr;
+    return make_ok_result(move(n));
+  }
+
   unique_ptr<vector<Message>> consumed = move(active);
   active.reset(new vector<Message>);
 
-  return consumed;
+  return make_ok_result(move(consumed));
 }
 
 size_t Queue::size()

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -46,3 +46,9 @@ unique_ptr<vector<Message>> Queue::accept_all()
 
   return consumed;
 }
+
+size_t Queue::size()
+{
+  Lock lock(mutex);
+  return active->size();
+}

--- a/src/queue.h
+++ b/src/queue.h
@@ -25,25 +25,25 @@ public:
   ~Queue();
 
   // Atomically enqueue a single Message.
-  Result<> &&enqueue(Message &&message);
+  Result<> enqueue(Message &&message);
 
   // Atomically enqueue a collection of Messages from a source STL container type between
   // the iterators [begin, end).
   template <class InputIt>
-  Result<> &&enqueue_all(InputIt begin, InputIt end)
+  Result<> enqueue_all(InputIt begin, InputIt end)
   {
-    if (!is_healthy()) return std::move(health_err_result());
+    if (!is_healthy()) return health_err_result();
 
     Lock lock(mutex);
     std::move(begin, end, std::back_inserter(*active));
-    return std::move(ok_result());
+    return ok_result();
   }
 
   // Atomically consume the current contents of the queue, emptying it.
   //
   // Returns a result containing unique_ptr to the vector of Messages, nullptr if no Messages were
   // present, or an error if the Queue is unhealthy.
-  Result< std::unique_ptr<std::vector<Message>> > &&accept_all();
+  Result< std::unique_ptr<std::vector<Message>> > accept_all();
 
   // Atomically report the number of items waiting on the queue.
   size_t size();

--- a/src/queue.h
+++ b/src/queue.h
@@ -41,6 +41,9 @@ public:
   // present.
   std::unique_ptr<std::vector<Message>> accept_all();
 
+  // Atomically report the number of items waiting on the queue.
+  size_t size();
+
 private:
   uv_mutex_t mutex;
   std::unique_ptr<std::vector<Message>> active;

--- a/src/result.h
+++ b/src/result.h
@@ -7,11 +7,6 @@
 
 #include "log.h"
 
-enum ResultState {
-  OK = 0,
-  ERROR = 1
-};
-
 // Container to be returned from method calls that may fail, optionally wrapping a return value.
 //
 // Result objects are expected to be stack-allocated and returned using move semantics or return-value optimization.
@@ -86,10 +81,10 @@ public:
   Result(Result<V> &&original) : state{original.state}, pending{false}
   {
     switch (state) {
-      case OK: // wat
+      case RESULT_OK:
         new (&value) V(std::move(original.value));
         break;
-      case ERROR:
+      case RESULT_ERROR:
         new (&error) std::string(std::move(original.error));
         break;
       default:
@@ -101,10 +96,10 @@ public:
   ~Result()
   {
     switch (state) {
-      case OK:
+      case RESULT_OK:
         value.~V();
         break;
-      case ERROR:
+      case RESULT_ERROR:
         error.~basic_string();
         break;
       default:
@@ -118,12 +113,12 @@ public:
 
   bool is_ok() const
   {
-    return state == OK;
+    return state == RESULT_OK;
   }
 
   bool is_error() const
   {
-    return state == ERROR;
+    return state == RESULT_ERROR;
   }
 
   V &get_value()
@@ -137,12 +132,12 @@ public:
   }
 
 private:
-  Result(V &&value) : state{OK}, value{std::move(value)}
+  Result(V &&value) : state{RESULT_OK}, value{std::move(value)}
   {
     //
   }
 
-  Result(std::string &&error, bool ignored) : state{ERROR}, error{std::move(error)}
+  Result(std::string &&error, bool ignored) : state{RESULT_ERROR}, error{std::move(error)}
   {
     //
   }
@@ -162,7 +157,10 @@ private:
     }
   }
 
-  ResultState state;
+  enum {
+    RESULT_OK = 0,
+    RESULT_ERROR
+  } state;
 
   union {
     V value;

--- a/src/result.h
+++ b/src/result.h
@@ -1,0 +1,129 @@
+#ifndef RESULT_H
+#define RESULT_H
+
+#include <utility>
+#include <string>
+#include <iostream>
+
+template< class V = void* >
+class Result {
+public:
+  static Result<V> &&make_ok(V &&value)
+  {
+    return std::move(Result<V>(std::move(value)));
+  }
+
+  static Result<V> &&make_error(std::string &&message)
+  {
+    return std::move(Result<V>(std::move(message), true));
+  }
+
+  Result(Result &&original) : state{original.state}, pending{true}
+  {
+    switch (state) {
+      case OK:
+        value = std::move(original.value);
+        break;
+      case ERROR:
+        error = std::move(original.error);
+        break;
+    }
+  }
+
+  ~Result()
+  {
+    switch (state) {
+      case OK:
+        value.~V();
+        break;
+      case ERROR:
+        error.~basic_string();
+        break;
+    }
+  }
+
+  bool is_ok() const
+  {
+    return state == OK;
+  }
+
+  bool is_error() const
+  {
+    return state == ERROR;
+  }
+
+  V& get_value()
+  {
+    return value;
+  }
+
+  const std::string& get_error() const
+  {
+    return error;
+  }
+
+private:
+  Result(V &&value) : state{OK}, value{std::move(value)}
+  {
+    //
+  }
+
+  Result(std::string &&error, bool ignored) : state{ERROR}, error{std::move(error)}
+  {
+    //
+  }
+
+  Result(const Result<V> &other) : state{other.state}, pending{true}
+  {
+    switch (state) {
+      case OK:
+        value = other.value;
+        break;
+      case ERROR:
+        error = other.error;
+        break;
+    }
+  }
+
+  enum {
+    OK = 0,
+    ERROR
+  } state;
+
+  union {
+    V value;
+    std::string error;
+    bool pending;
+  };
+
+  friend Result<void*> &&ok_result();
+};
+
+template < class V >
+Result<V> &&make_ok_result(V &&value)
+{
+  return std::move(Result<V>::make_ok(std::move(value)));
+}
+
+inline Result<void*> &&ok_result()
+{
+  return std::move(Result<void*>::make_ok(nullptr));
+}
+
+inline Result<void*> &&error_result(std::string &&message)
+{
+  return Result<void*>::make_error(std::move(message));
+}
+
+template < class V >
+std::ostream &operator<<(std::ostream &out, const Result<V> &result)
+{
+  if (result.is_error()) {
+    out << result.get_error();
+  } else {
+    out << "OK";
+  }
+  return out;
+}
+
+#endif

--- a/src/result.h
+++ b/src/result.h
@@ -99,10 +99,7 @@ private:
     }
   }
 
-  enum {
-    OK = 0,
-    ERROR
-  } state;
+  enum {OK = 0, ERROR = 1} state;
 
   union {
     V value;

--- a/src/result.h
+++ b/src/result.h
@@ -162,7 +162,7 @@ private:
     }
   }
 
-  enum {OK = 0, ERROR = 1} state;
+  ResultState state;
 
   union {
     V value;

--- a/src/result.h
+++ b/src/result.h
@@ -145,10 +145,10 @@ private:
   Result(const Result<V> &original) : state{original.state}, pending{false}
   {
     switch (state) {
-      case OK:
+      case RESULT_OK:
         new (&value) V(original.value);
         break;
-      case ERROR:
+      case RESULT_ERROR:
         new (&error) std::string(original.error);
         break;
       default:

--- a/src/result.h
+++ b/src/result.h
@@ -7,6 +7,69 @@
 
 #include "log.h"
 
+enum ResultState {
+  OK = 0,
+  ERROR = 1
+};
+
+// Container to be returned from method calls that may fail, optionally wrapping a return value.
+//
+// Result objects are expected to be stack-allocated and returned using move semantics or return-value optimization.
+// As a consequence, wrapped return values must have valid move constructors.
+//
+// To construct them, use the static {Result<>::make_ok} or {Result<>::make_error} methods:
+//
+// ```
+// Result<int> r0 = Result<int>::make_ok(12);
+//
+// Result<int> r1 = Result<int>::make_error("something went wrong");
+// ```
+//
+// For the common case of returning void, use the shorthand {ok_result()} and {error_result()} functions:
+//
+// ```
+// Result<> r2 = ok_result();
+//
+// Result<> r3 = error_result("oh no");
+// ```
+//
+// When returning a concrete value, the {ok_result()} override can also be useful for brevity:
+//
+// ```
+// Result<int> r4 = ok_result(12);
+// ```
+//
+// After construction, return them directly from a function, not by pointer, reference, or xvalue (`&&`):
+//
+// ```
+// Result<int> get_value(bool succeed)
+// {
+//   if (succeed) {
+//     return ok_result(12);
+//   } else {
+//     return Result<int>::make_error("oh no");
+//   }
+// }
+// ```
+//
+// To consume a function that returns a Result, check for success with {is_error()} or {is_ok()}, then either return it
+// up the stack, process the error message extracted with {get_error()}, or process the return value extracted with
+// {get_value()}. Note that {get_value()} returns a reference.
+//
+// ```
+// Result<int> stuff()
+// {
+//   Result<int> r = other_method();
+//   if (r.is_error()) {
+//     LOGGER << "The error was: " << r << std::endl;
+//     return r;
+//   }
+//
+//   int &foo = r.get_value();
+//
+//   return ok_result(foo + 10);
+// }
+// ```
 template< class V = void* >
 class Result {
 public:

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <iomanip>
+
+#include "status.h"
+#include "log.h"
+
+using std::ostream;
+using std::endl;
+
+ostream &operator<<(ostream &out, const Status &status)
+{
+  out << "SFW STATUS SUMMARY\n"
+    << "* main thread:\n"
+    << "  - " << plural(status.pending_callback_count, "pending callback") << "\n"
+    << "  - " << plural(status.channel_callback_count, "channel callback") << "\n"
+    << "* worker thread:\n"
+    << "  - health: " << status.worker_thread_ok << "\n"
+    << "  - in queue health: " << status.worker_in_ok << "\n"
+    << "  - " << plural(status.worker_in_size, "in queue message") << "\n"
+    << "  - out queue health: " << status.worker_out_ok << "\n"
+    << "  - " << plural(status.worker_out_size, "out queue message")
+    << endl;
+  return out;
+}

--- a/src/status.h
+++ b/src/status.h
@@ -1,0 +1,25 @@
+#ifndef STATUS_H
+#define STATUS_H
+
+#include <string>
+#include <iostream>
+
+// Summarize the module's health. This includes information like the health of all Errable and SyncErrable
+// resources and the sizes of internal queues and buffers.
+class Status {
+public:
+  // Main thread
+  size_t pending_callback_count;
+  size_t channel_callback_count;
+
+  // Worker thread
+  std::string worker_thread_ok;
+  size_t worker_in_size;
+  std::string worker_in_ok;
+  size_t worker_out_size;
+  std::string worker_out_ok;
+};
+
+std::ostream &operator<<(std::ostream &out, const Status &status);
+
+#endif

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -16,47 +16,68 @@ using std::move;
 
 void thread_callback_helper(void *arg)
 {
-  function<void()> *bound_fn = (std::function<void()>*) arg;
+  function<void()> *bound_fn = static_cast<std::function<void()>*>(arg);
   (*bound_fn)();
 }
 
-void Thread::run()
+Result<> &&Thread::run()
 {
   int err;
 
   err = uv_thread_create(&uv_handle, thread_callback_helper, &work_fn);
-  report_uv_error(err);
+  if (err) {
+    report_uv_error(err);
+    return health_err_result();
+  } else {
+    return ok_result();
+  }
 }
 
-void Thread::send(Message &&message)
+Result<> &&Thread::send(Message &&message)
 {
-  if (!is_healthy()) return;
-  in.enqueue(move(message));
-  wake();
+  if (!is_healthy()) return health_err_result();
+
+  Result<> qr = in.enqueue(move(message));
+  if (qr.is_error()) return move(qr);
+
+  Result<> wr = wake();
+  if (wr.is_error()) return move(wr);
+
+  return ok_result();
 }
 
-unique_ptr<vector<Message>> Thread::receive_all()
+Result< unique_ptr<vector<Message>> > &&Thread::receive_all()
 {
-  if (!is_healthy()) return nullptr;
+  if (!is_healthy()) return health_err_result< unique_ptr<vector<Message>> >();
+
   return out.accept_all();
 }
 
-void Thread::emit(Message &&message)
+Result<> &&Thread::emit(Message &&message)
 {
-  if (!is_healthy()) return;
-  out.enqueue(move(message));
-  uv_async_send(main_callback);
+  if (!is_healthy()) return health_err_result();
+
+  Result<> qr = out.enqueue(move(message));
+  if (qr.is_error()) return move(qr);
+
+  int uv_err = uv_async_send(main_callback);
+  if (uv_err) {
+    return error_result(uv_strerror(uv_err));
+  }
+
+  return ok_result();
 }
 
-unique_ptr<vector<Message>> Thread::process_all()
+Result< unique_ptr<vector<Message>> > &&Thread::process_all()
 {
-  if (!is_healthy()) return nullptr;
+  if (!is_healthy()) return health_err_result< unique_ptr<vector<Message>> >();
+
   return in.accept_all();
 }
 
-void Thread::wake()
+Result<> &&Thread::wake()
 {
-  //
+  return ok_result();
 }
 
 string Thread::get_in_queue_error()

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -1,3 +1,4 @@
+#include <string>
 #include <memory>
 #include <functional>
 #include <vector>
@@ -7,6 +8,7 @@
 #include "thread.h"
 #include "message.h"
 
+using std::string;
 using std::function;
 using std::unique_ptr;
 using std::vector;
@@ -55,4 +57,24 @@ unique_ptr<vector<Message>> Thread::process_all()
 void Thread::wake()
 {
   //
+}
+
+string Thread::get_in_queue_error()
+{
+  return in.get_error();
+}
+
+size_t Thread::get_in_queue_size()
+{
+  return in.size();
+}
+
+string Thread::get_out_queue_error()
+{
+  return out.get_error();
+}
+
+size_t Thread::get_out_queue_size()
+{
+  return out.size();
 }

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -20,7 +20,7 @@ void thread_callback_helper(void *arg)
   (*bound_fn)();
 }
 
-Result<> &&Thread::run()
+Result<> Thread::run()
 {
   int err;
 
@@ -33,32 +33,32 @@ Result<> &&Thread::run()
   }
 }
 
-Result<> &&Thread::send(Message &&message)
+Result<> Thread::send(Message &&message)
 {
   if (!is_healthy()) return health_err_result();
 
   Result<> qr = in.enqueue(move(message));
-  if (qr.is_error()) return move(qr);
+  if (qr.is_error()) return qr;
 
   Result<> wr = wake();
-  if (wr.is_error()) return move(wr);
+  if (wr.is_error()) return wr;
 
   return ok_result();
 }
 
-Result< unique_ptr<vector<Message>> > &&Thread::receive_all()
+Result< unique_ptr<vector<Message>> > Thread::receive_all()
 {
   if (!is_healthy()) return health_err_result< unique_ptr<vector<Message>> >();
 
   return out.accept_all();
 }
 
-Result<> &&Thread::emit(Message &&message)
+Result<> Thread::emit(Message &&message)
 {
   if (!is_healthy()) return health_err_result();
 
   Result<> qr = out.enqueue(move(message));
-  if (qr.is_error()) return move(qr);
+  if (qr.is_error()) return qr;
 
   int uv_err = uv_async_send(main_callback);
   if (uv_err) {
@@ -68,14 +68,14 @@ Result<> &&Thread::emit(Message &&message)
   return ok_result();
 }
 
-Result< unique_ptr<vector<Message>> > &&Thread::process_all()
+Result< unique_ptr<vector<Message>> > Thread::process_all()
 {
   if (!is_healthy()) return health_err_result< unique_ptr<vector<Message>> >();
 
   return in.accept_all();
 }
 
-Result<> &&Thread::wake()
+Result<> Thread::wake()
 {
   return ok_result();
 }

--- a/src/thread.h
+++ b/src/thread.h
@@ -1,6 +1,7 @@
 #ifndef THREAD_H
 #define THREAD_H
 
+#include <string>
 #include <memory>
 #include <functional>
 #include <vector>
@@ -9,10 +10,11 @@
 #include "errable.h"
 #include "queue.h"
 #include "message.h"
+#include "status.h"
 
 void thread_callback_helper(void *arg);
 
-class Thread : SyncErrable {
+class Thread : public SyncErrable {
 public:
   template< class T >
   Thread(T* self, void (T::*fn)(), uv_async_t *main_callback) :
@@ -36,6 +38,8 @@ public:
 
   std::unique_ptr<std::vector<Message>> receive_all();
 
+  virtual void collect_status(Status &status) = 0;
+
 protected:
   virtual void wake();
 
@@ -50,6 +54,11 @@ protected:
   }
 
   std::unique_ptr<std::vector<Message>> process_all();
+
+  std::string get_in_queue_error();
+  size_t get_in_queue_size();
+  std::string get_out_queue_error();
+  size_t get_out_queue_size();
 
 private:
   Queue in;

--- a/src/thread.h
+++ b/src/thread.h
@@ -3,11 +3,13 @@
 
 #include <string>
 #include <memory>
+#include <utility>
 #include <functional>
 #include <vector>
 #include <uv.h>
 
 #include "errable.h"
+#include "result.h"
 #include "queue.h"
 #include "message.h"
 #include "status.h"
@@ -17,43 +19,60 @@ void thread_callback_helper(void *arg);
 class Thread : public SyncErrable {
 public:
   template< class T >
-  Thread(T* self, void (T::*fn)(), uv_async_t *main_callback) :
+  Thread(T* self, void (T::*fn)(), std::string name, uv_async_t *main_callback) :
+    SyncErrable(name),
+    in(name + " input queue"),
+    out(name + " output queue"),
     main_callback{main_callback},
     work_fn{std::bind(std::mem_fn(fn), self)}
   {
     //
   };
 
-  void run();
+  Result<> &&run();
 
-  void send(Message &&message);
+  Result<> &&send(Message &&message);
 
   template <class InputIt>
-  void send_all(InputIt begin, InputIt end)
+  Result<> &&send_all(InputIt begin, InputIt end)
   {
-    if (!is_healthy()) return;
-    in.enqueue_all(begin, end);
-    wake();
+    if (!is_healthy()) return health_err_result();
+
+    Result<> qr = in.enqueue_all(begin, end);
+    if (qr.is_error()) return std::move(qr);
+
+    Result<> wr = wake();
+    if (wr.is_error()) return std::move(wr);
+
+    return std::move(ok_result());
   }
 
-  std::unique_ptr<std::vector<Message>> receive_all();
+  Result< std::unique_ptr<std::vector<Message>> > &&receive_all();
 
   virtual void collect_status(Status &status) = 0;
 
 protected:
-  virtual void wake();
+  virtual Result<> &&wake();
 
-  void emit(Message &&message);
+  Result<> &&emit(Message &&message);
 
   template <class InputIt>
-  void emit_all(InputIt begin, InputIt end)
+  Result<> &&emit_all(InputIt begin, InputIt end)
   {
-    if (!is_healthy()) return;
-    out.enqueue_all(begin, end);
-    uv_async_send(main_callback);
+    if (!is_healthy()) return health_err_result();
+
+    Result<> qr = out.enqueue_all(begin, end);
+    if (qr.is_error()) return std::move(qr);
+
+    int uv_err = uv_async_send(main_callback);
+    if (uv_err) {
+      return error_result(uv_strerror(uv_err));
+    }
+
+    return ok_result();
   }
 
-  std::unique_ptr<std::vector<Message>> process_all();
+  Result< std::unique_ptr<std::vector<Message>> > &&process_all();
 
   std::string get_in_queue_error();
   size_t get_in_queue_size();

--- a/src/thread.h
+++ b/src/thread.h
@@ -29,40 +29,40 @@ public:
     //
   };
 
-  Result<> &&run();
+  Result<> run();
 
-  Result<> &&send(Message &&message);
+  Result<> send(Message &&message);
 
   template <class InputIt>
-  Result<> &&send_all(InputIt begin, InputIt end)
+  Result<> send_all(InputIt begin, InputIt end)
   {
     if (!is_healthy()) return health_err_result();
 
     Result<> qr = in.enqueue_all(begin, end);
-    if (qr.is_error()) return std::move(qr);
+    if (qr.is_error()) return qr;
 
     Result<> wr = wake();
-    if (wr.is_error()) return std::move(wr);
+    if (wr.is_error()) return wr;
 
-    return std::move(ok_result());
+    return ok_result();
   }
 
-  Result< std::unique_ptr<std::vector<Message>> > &&receive_all();
+  Result< std::unique_ptr<std::vector<Message>> > receive_all();
 
   virtual void collect_status(Status &status) = 0;
 
 protected:
-  virtual Result<> &&wake();
+  virtual Result<> wake();
 
-  Result<> &&emit(Message &&message);
+  Result<> emit(Message &&message);
 
   template <class InputIt>
-  Result<> &&emit_all(InputIt begin, InputIt end)
+  Result<> emit_all(InputIt begin, InputIt end)
   {
     if (!is_healthy()) return health_err_result();
 
     Result<> qr = out.enqueue_all(begin, end);
-    if (qr.is_error()) return std::move(qr);
+    if (qr.is_error()) return qr;
 
     int uv_err = uv_async_send(main_callback);
     if (uv_err) {
@@ -72,7 +72,7 @@ protected:
     return ok_result();
   }
 
-  Result< std::unique_ptr<std::vector<Message>> > &&process_all();
+  Result< std::unique_ptr<std::vector<Message>> > process_all();
 
   std::string get_in_queue_error();
   size_t get_in_queue_size();

--- a/src/thread.h
+++ b/src/thread.h
@@ -12,7 +12,7 @@
 
 void thread_callback_helper(void *arg);
 
-class Thread : Errable {
+class Thread : SyncErrable {
 public:
   template< class T >
   Thread(T* self, void (T::*fn)(), uv_async_t *main_callback) :

--- a/src/worker/linux/linux_worker_platform.cpp
+++ b/src/worker/linux/linux_worker_platform.cpp
@@ -14,22 +14,22 @@ class LinuxWorkerPlatform : public WorkerPlatform {
 public:
   LinuxWorkerPlatform(WorkerThread *thread) : WorkerPlatform(thread) {};
 
-  Result<> &&wake() override
+  Result<> wake() override
   {
     return ok_result();
   }
 
-  Result<> &&listen() override
+  Result<> listen() override
   {
     return ok_result();
   }
 
-  Result<> &&handle_add_command(const ChannelID channel, const string &root_path)
+  Result<> handle_add_command(const ChannelID channel, const string &root_path)
   {
     return ok_result();
   }
 
-  Result<> &&handle_remove_command(const ChannelID channel)
+  Result<> handle_remove_command(const ChannelID channel)
   {
     return ok_result();
   }

--- a/src/worker/linux/linux_worker_platform.cpp
+++ b/src/worker/linux/linux_worker_platform.cpp
@@ -5,6 +5,7 @@
 #include "../worker_thread.h"
 #include "../../message.h"
 #include "../../log.h"
+#include "../../result.h"
 
 using std::string;
 using std::unique_ptr;
@@ -13,24 +14,24 @@ class LinuxWorkerPlatform : public WorkerPlatform {
 public:
   LinuxWorkerPlatform(WorkerThread *thread) : WorkerPlatform(thread) {};
 
-  void wake() override
+  Result<> &&wake() override
   {
-    //
+    return ok_result();
   }
 
-  void listen() override
+  Result<> &&listen() override
   {
-    //
+    return ok_result();
   }
 
-  void handle_add_command(const ChannelID channel, const string &root_path)
+  Result<> &&handle_add_command(const ChannelID channel, const string &root_path)
   {
-    //
+    return ok_result();
   }
 
-  void handle_remove_command(const ChannelID channel)
+  Result<> &&handle_remove_command(const ChannelID channel)
   {
-    //
+    return ok_result();
   }
 };
 

--- a/src/worker/macos/macos_worker_platform.cpp
+++ b/src/worker/macos/macos_worker_platform.cpp
@@ -71,7 +71,7 @@ public:
     if (run_loop) CFRelease(run_loop);
   }
 
-  Result<> &&wake() override
+  Result<> wake() override
   {
     CFRunLoopSourceSignal(command_source);
     CFRunLoopWakeUp(run_loop);
@@ -79,7 +79,7 @@ public:
     return ok_result();
   }
 
-  Result<> &&listen() override
+  Result<> listen() override
   {
     run_loop = CFRunLoopGetCurrent();
     CFRetain(run_loop);
@@ -103,7 +103,7 @@ public:
     return ok_result();
   }
 
-  Result<> &&handle_add_command(const ChannelID channel, const string &root_path) override
+  Result<> handle_add_command(const ChannelID channel, const string &root_path) override
   {
     LOGGER << "Adding watcher for path " << root_path << " at channel " << channel << "." << endl;
 
@@ -165,7 +165,7 @@ public:
       CFRelease(watch_roots);
       CFRelease(watch_root);
       FSEventStreamRelease(event_stream);
-      return error_result(msg);
+      return error_result(move(msg));
     }
 
     CFRelease(watch_roots);
@@ -173,7 +173,7 @@ public:
     return ok_result();
   }
 
-  Result<> &&handle_remove_command(const ChannelID channel) override
+  Result<> handle_remove_command(const ChannelID channel) override
   {
     LOGGER << "Removing watcher for channel " << channel << "." << endl;
 

--- a/src/worker/macos/macos_worker_platform.cpp
+++ b/src/worker/macos/macos_worker_platform.cpp
@@ -73,6 +73,8 @@ public:
 
   Result<> wake() override
   {
+    if (!is_healthy()) return health_err_result();
+
     CFRunLoopSourceSignal(command_source);
     CFRunLoopWakeUp(run_loop);
 
@@ -81,6 +83,8 @@ public:
 
   Result<> listen() override
   {
+    if (!is_healthy()) return health_err_result();
+
     run_loop = CFRunLoopGetCurrent();
     CFRetain(run_loop);
 
@@ -105,6 +109,7 @@ public:
 
   Result<> handle_add_command(const ChannelID channel, const string &root_path) override
   {
+    if (!is_healthy()) return health_err_result();
     LOGGER << "Adding watcher for path " << root_path << " at channel " << channel << "." << endl;
 
     Subscription *subscription = new Subscription(this, channel);
@@ -175,6 +180,7 @@ public:
 
   Result<> handle_remove_command(const ChannelID channel) override
   {
+    if (!is_healthy()) return health_err_result();
     LOGGER << "Removing watcher for channel " << channel << "." << endl;
 
     auto maybe_subscription = subscriptions.find(channel);

--- a/src/worker/windows/windows_worker_platform.cpp
+++ b/src/worker/windows/windows_worker_platform.cpp
@@ -13,24 +13,24 @@ class WindowsWorkerPlatform : public WorkerPlatform {
 public:
   WindowsWorkerPlatform(WorkerThread *thread) : WorkerPlatform(thread) {};
 
-  void wake() override
+  Result<> wake() override
   {
-    //
+    return ok_result();
   }
 
-  void listen() override
+  Result<> listen() override
   {
-    //
+    return ok_result();
   }
 
-  void handle_add_command(const ChannelID channel, const string &root_path)
+  Result<> handle_add_command(const ChannelID channel, const string &root_path)
   {
-    //
+    return ok_result();
   }
 
-  void handle_remove_command(const ChannelID channel)
+  Result<> handle_remove_command(const ChannelID channel)
   {
-    //
+    return ok_result();
   }
 };
 

--- a/src/worker/worker_platform.h
+++ b/src/worker/worker_platform.h
@@ -15,13 +15,13 @@ public:
 
   virtual ~WorkerPlatform() {};
 
-  virtual Result<> &&wake() = 0;
+  virtual Result<> wake() = 0;
 
-  virtual Result<> &&listen() = 0;
-  virtual Result<> &&handle_add_command(const ChannelID channel, const std::string &root_path) = 0;
-  virtual Result<> &&handle_remove_command(const ChannelID channel) = 0;
+  virtual Result<> listen() = 0;
+  virtual Result<> handle_add_command(const ChannelID channel, const std::string &root_path) = 0;
+  virtual Result<> handle_remove_command(const ChannelID channel) = 0;
 
-  Result<> &&handle_commands()
+  Result<> handle_commands()
   {
     return thread->handle_commands();
   }
@@ -32,13 +32,13 @@ protected:
     //
   }
 
-  Result<> &&emit(Message &&message)
+  Result<> emit(Message &&message)
   {
     return thread->emit(std::move(message));
   }
 
   template <class InputIt>
-  Result<> &&emit_all(InputIt begin, InputIt end)
+  Result<> emit_all(InputIt begin, InputIt end)
   {
     return thread->emit_all(begin, end);
   }

--- a/src/worker/worker_platform.h
+++ b/src/worker/worker_platform.h
@@ -7,6 +7,7 @@
 
 #include "worker_thread.h"
 #include "../message.h"
+#include "../result.h"
 
 class WorkerPlatform {
 public:
@@ -14,15 +15,15 @@ public:
 
   virtual ~WorkerPlatform() {};
 
-  virtual void wake() = 0;
+  virtual Result<> &&wake() = 0;
 
-  virtual void listen() = 0;
-  virtual void handle_add_command(const ChannelID channel, const std::string &root_path) = 0;
-  virtual void handle_remove_command(const ChannelID channel) = 0;
+  virtual Result<> &&listen() = 0;
+  virtual Result<> &&handle_add_command(const ChannelID channel, const std::string &root_path) = 0;
+  virtual Result<> &&handle_remove_command(const ChannelID channel) = 0;
 
-  void handle_commands()
+  Result<> &&handle_commands()
   {
-    thread->handle_commands();
+    return thread->handle_commands();
   }
 
 protected:
@@ -31,15 +32,15 @@ protected:
     //
   }
 
-  void emit(Message &&message)
+  Result<> &&emit(Message &&message)
   {
-    thread->emit(std::move(message));
+    return thread->emit(std::move(message));
   }
 
   template <class InputIt>
-  void emit_all(InputIt begin, InputIt end)
+  Result<> &&emit_all(InputIt begin, InputIt end)
   {
-    thread->emit_all(begin, end);
+    return thread->emit_all(begin, end);
   }
 
   WorkerThread *thread;

--- a/src/worker/worker_thread.cpp
+++ b/src/worker/worker_thread.cpp
@@ -83,3 +83,12 @@ void WorkerThread::handle_commands()
 
   emit_all(acks.begin(), acks.end());
 }
+
+void WorkerThread::collect_status(Status &status)
+{
+  status.worker_thread_ok = get_error();
+  status.worker_in_size = get_in_queue_size();
+  status.worker_in_ok = get_in_queue_error();
+  status.worker_out_size = get_out_queue_size();
+  status.worker_out_ok = get_out_queue_error();
+}

--- a/src/worker/worker_thread.cpp
+++ b/src/worker/worker_thread.cpp
@@ -2,6 +2,7 @@
 #include <memory>
 #include <iostream>
 #include <utility>
+#include <string>
 #include <uv.h>
 
 #include "worker_thread.h"
@@ -9,14 +10,16 @@
 #include "../log.h"
 #include "../queue.h"
 #include "../message.h"
+#include "../result.h"
 
 using std::endl;
 using std::vector;
 using std::unique_ptr;
 using std::move;
+using std::string;
 
 WorkerThread::WorkerThread(uv_async_t *main_callback) :
-  Thread(this, &WorkerThread::listen, main_callback),
+  Thread(this, &WorkerThread::listen, "worker thread", main_callback),
   platform{WorkerPlatform::for_worker(this)}
 {
   //
@@ -27,24 +30,39 @@ WorkerThread::~WorkerThread()
   // Necessary so that unique_ptr can see the full definition of WorkerPlatform
 }
 
-void WorkerThread::wake()
+Result<> &&WorkerThread::wake()
 {
-  platform->wake();
+  return platform->wake();
 }
 
 void WorkerThread::listen()
 {
   // Handle any commands that were enqueued while the thread was starting.
-  handle_commands();
+  Result<> cr = handle_commands();
+  if (cr.is_error()) {
+    LOGGER << "Unable to handle initially enqueued commands: " << cr << endl;
+  }
 
-  platform->listen();
+  Result<> lr = platform->listen();
+  if (lr.is_error()) {
+    LOGGER << "Unable to listen: " << lr << endl;
+    report_error(string(lr.get_error()));
+  } else {
+    LOGGER << "listen unexpectedly returned without reporting an error." << endl;
+  }
 }
 
-void WorkerThread::handle_commands()
+Result<> &&WorkerThread::handle_commands()
 {
-  unique_ptr<vector<Message>> accepted = process_all();
+  Result< unique_ptr<vector<Message>> > pr = process_all();
+  if (pr.is_error()) {
+    return error_result(string(pr.get_error()));
+  }
+
+  unique_ptr<vector<Message>> &accepted = pr.get_value();
   if (!accepted) {
-    return;
+    // No command messages to accept.
+    return ok_result();
   }
 
   vector<Message> acks;
@@ -57,6 +75,7 @@ void WorkerThread::handle_commands()
       continue;
     }
 
+    // TODO detect errors are use them to construct the Ack
     switch (command->get_action()) {
       case COMMAND_ADD:
         platform->handle_add_command(command->get_channel_id(), command->get_root());
@@ -81,7 +100,7 @@ void WorkerThread::handle_commands()
     acks.push_back(move(response));
   }
 
-  emit_all(acks.begin(), acks.end());
+  return emit_all(acks.begin(), acks.end());
 }
 
 void WorkerThread::collect_status(Status &status)

--- a/src/worker/worker_thread.cpp
+++ b/src/worker/worker_thread.cpp
@@ -30,7 +30,7 @@ WorkerThread::~WorkerThread()
   // Necessary so that unique_ptr can see the full definition of WorkerPlatform
 }
 
-Result<> &&WorkerThread::wake()
+Result<> WorkerThread::wake()
 {
   return platform->wake();
 }
@@ -52,7 +52,7 @@ void WorkerThread::listen()
   }
 }
 
-Result<> &&WorkerThread::handle_commands()
+Result<> WorkerThread::handle_commands()
 {
   Result< unique_ptr<vector<Message>> > pr = process_all();
   if (pr.is_error()) {

--- a/src/worker/worker_thread.h
+++ b/src/worker/worker_thread.h
@@ -20,10 +20,10 @@ public:
   void collect_status(Status &status) override;
 
 private:
-  Result<> &&wake() override;
+  Result<> wake() override;
 
   void listen();
-  Result<> &&handle_commands();
+  Result<> handle_commands();
 
   std::unique_ptr<WorkerPlatform> platform;
   friend WorkerPlatform;

--- a/src/worker/worker_thread.h
+++ b/src/worker/worker_thread.h
@@ -8,6 +8,7 @@
 #include "../message.h"
 #include "../thread.h"
 #include "../status.h"
+#include "../result.h"
 
 class WorkerPlatform;
 
@@ -19,10 +20,10 @@ public:
   void collect_status(Status &status) override;
 
 private:
-  void wake() override;
+  Result<> &&wake() override;
 
   void listen();
-  void handle_commands();
+  Result<> &&handle_commands();
 
   std::unique_ptr<WorkerPlatform> platform;
   friend WorkerPlatform;

--- a/src/worker/worker_thread.h
+++ b/src/worker/worker_thread.h
@@ -7,6 +7,7 @@
 #include "../queue.h"
 #include "../message.h"
 #include "../thread.h"
+#include "../status.h"
 
 class WorkerPlatform;
 
@@ -15,12 +16,13 @@ public:
   WorkerThread(uv_async_t *main_callback);
   ~WorkerThread();
 
+  void collect_status(Status &status) override;
+
 private:
   void wake() override;
 
   void listen();
   void handle_commands();
-
 
   std::unique_ptr<WorkerPlatform> platform;
   friend WorkerPlatform;

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -26,8 +26,8 @@ describe('entry point', function () {
         [mainLogFile, workerLogFile].map(fname => fs.readFile(fname, {encoding: 'utf8'}).catch(() => ''))
       )
 
-      console.log(`main log:\n${mainLog}`)
-      console.log(`worker log:\n${workerLog}`)
+      console.log(`main log ${mainLogFile}:\n${mainLog}`)
+      console.log(`worker log ${workerLogFile}:\n${workerLog}`)
     }
 
     await Promise.all([


### PR DESCRIPTION
Improve the error reporting mechanism.

- [x] Make a thread-safe `Errable` subclass so that an error state set by the worker thread can safely be read from the main thread.
  - [x] Introduce `ReadLock` and `WriteLock` to manage `uv_rwlock_t` RAII-style
- [x] Collect and report a status summary of all resources and queues as a quick health check
- [x] Return a `Result` type to report error conditions consistently
- [x] Make `Platform` an `Errable` for local error reporting
- [x] Reject callbacks with a JavaScript error if an `AckPayload` includes an error
- [x] Throw a JavaScript exception in the main thread if the worker thread is unhealthy
- [x] Document the `Result<>` stuff for when I inevitably forget how it works
- [ ] Fix Windows build errors