### PR TITLE
Disable logging

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,9 +77,19 @@ public:
     Logger::to_file(main_log_file.c_str());
   }
 
+  void disable_main_log()
+  {
+    Logger::disable();
+  }
+
   Result<> use_worker_log_file(string &&worker_log_file, unique_ptr<Nan::Callback> callback)
   {
     return send_worker_command(COMMAND_LOG_FILE, move(worker_log_file), move(callback));
+  }
+
+  Result<> disable_worker_log(unique_ptr<Nan::Callback> callback)
+  {
+    return send_worker_command(COMMAND_LOG_DISABLE, "", move(callback));
   }
 
   Result<> watch(string &&root, unique_ptr<Nan::Callback> ack_callback, unique_ptr<Nan::Callback> event_callback)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -318,9 +318,20 @@ void configure(const Nan::FunctionCallbackInfo<Value> &info)
   if (!main_log_file.empty()) {
     instance.use_main_log_file(move(main_log_file));
   }
+  if (main_log_file_null) {
+    instance.disable_main_log();
+  }
 
   if (!worker_log_file.empty()) {
     Result<> r = instance.use_worker_log_file(move(worker_log_file), move(callback));
+    if (r.is_error()) {
+      Nan::ThrowError(r.get_error().c_str());
+      return;
+    }
+    async = true;
+  }
+  if (worker_log_file_null) {
+    Result<> r = instance.disable_worker_log(move(callback));
     if (r.is_error()) {
       Nan::ThrowError(r.get_error().c_str());
       return;

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -16,7 +16,7 @@ describe('entry point', function () {
     workerLogFile = path.join(fixtureDir, 'worker.test.log')
 
     await Promise.all([
-      [mainLogFile, workerLogFile].map(fname => fs.readFile(fname, {encoding: 'utf8'}).catch(() => ''))
+      [mainLogFile, workerLogFile].map(fname => fs.unlink(fname, {encoding: 'utf8'}).catch(() => ''))
     ])
   })
 

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -9,8 +9,10 @@ describe('entry point', function () {
   beforeEach(async function () {
     subs = []
 
-    fixtureDir = path.join(__dirname, 'fixture')
-    watchDir = await fs.mkdtemp(path.join(fixtureDir, 'watched-'))
+    const rootDir = path.join(__dirname, 'fixture')
+    fixtureDir = await fs.mkdtemp(path.join(rootDir, 'watched-'))
+    watchDir = path.join(fixtureDir, 'root')
+    await fs.mkdirs(watchDir)
 
     mainLogFile = path.join(fixtureDir, 'main.test.log')
     workerLogFile = path.join(fixtureDir, 'worker.test.log')

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -37,7 +37,7 @@ describe('entry point', function () {
     }
 
     await Promise.all([
-      fs.remove(watchDir),
+      fs.remove(fixtureDir),
       ...subs.map(sub => sub.unwatch())
     ])
   })

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -21,7 +21,11 @@ describe('entry point', function () {
   })
 
   afterEach(async function () {
-    if (this.currentTest.state === 'failed') {
+    if (process.platform === 'win32') {
+      await watcher.configure({mainLogFile: false, workerLogFile: false})
+    }
+
+    if (this.currentTest.state === 'failed' || process.env.VERBOSE) {
       const [mainLog, workerLog] = await Promise.all(
         [mainLogFile, workerLogFile].map(fname => fs.readFile(fname, {encoding: 'utf8'}).catch(() => ''))
       )

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -22,7 +22,7 @@ describe('entry point', function () {
 
   afterEach(async function () {
     if (process.platform === 'win32') {
-      await watcher.configure({mainLogFile: false, workerLogFile: false})
+      await watcher.configure({mainLogFile: null, workerLogFile: null})
     }
 
     if (this.currentTest.state === 'failed' || process.env.VERBOSE) {


### PR DESCRIPTION
Allow users to disable logging by passing `null` to the configure function.

This is necessary for the tests to work properly on Windows. Otherwise, the worker thread prevents the `afterEach()` hook from being able to clean up its fixture directory properly.