### PR TITLE
Use inotify to watch directories on Linux.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -46,6 +46,7 @@
             ["OS=='linux'", {
                 "sources": [
                     "src/worker/linux/pipe.cpp",
+                    "src/worker/linux/cookie_jar.cpp",
                     "src/worker/linux/watched_directory.cpp",
                     "src/worker/linux/watch_registry.cpp",
                     "src/worker/linux/linux_worker_platform.cpp"

--- a/binding.gyp
+++ b/binding.gyp
@@ -46,6 +46,7 @@
             ["OS=='linux'", {
                 "sources": [
                     "src/worker/linux/pipe.cpp",
+                    "src/worker/linux/side_effect.cpp",
                     "src/worker/linux/cookie_jar.cpp",
                     "src/worker/linux/watched_directory.cpp",
                     "src/worker/linux/watch_registry.cpp",

--- a/binding.gyp
+++ b/binding.gyp
@@ -9,6 +9,7 @@
             "src/queue.cpp",
             "src/lock.cpp",
             "src/message.cpp",
+            "src/message_buffer.cpp",
             "src/thread.cpp",
             "src/status.cpp",
             "src/worker/worker_thread.cpp"

--- a/binding.gyp
+++ b/binding.gyp
@@ -46,6 +46,8 @@
             ["OS=='linux'", {
                 "sources": [
                     "src/worker/linux/pipe.cpp",
+                    "src/worker/linux/watched_directory.cpp",
+                    "src/worker/linux/watch_registry.cpp",
                     "src/worker/linux/linux_worker_platform.cpp"
                 ]
             }]

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ci:appveyor": "npm run mocha -- --fgrep ^windows --invert --reporter mocha-appveyor-reporter --reporter-options appveyorBatchSize=5",
     "ci:circle": "npm run mocha -- --fgrep '^mac' --invert --reporter mocha-junit-reporter --reporter-options mochaFile=${CIRCLE_TEST_REPORTS}/mocha/test-results.xml",
     "ci:travis": "npm run mocha -- --fgrep '^linux' --invert --reporter list",
-    "aw:test": "clear && npm run build:debug && clear && npm run mocha",
+    "aw:test": "npm run clean:fixture && clear && npm run build:debug && clear && npm run mocha",
     "clean:fixture": "rm -rf test/fixture/*.log test/fixture/watched-*",
     "install": "cross-env NODE_DEBUG=request node-gyp rebuild --loglevel=silly"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ci:circle": "npm run mocha -- --fgrep '^mac' --invert --reporter mocha-junit-reporter --reporter-options mochaFile=${CIRCLE_TEST_REPORTS}/mocha/test-results.xml",
     "ci:travis": "npm run mocha -- --fgrep '^linux' --invert --reporter list",
     "aw:test": "clear && npm run build:debug && clear && npm run mocha",
-    "clean:fixture": "rm -r test/fixture/*.log test/fixture/watched-*",
+    "clean:fixture": "rm -rf test/fixture/*.log test/fixture/watched-*",
     "install": "cross-env NODE_DEBUG=request node-gyp rebuild --loglevel=silly"
   },
   "keywords": [

--- a/src/helper/linux/helper.h
+++ b/src/helper/linux/helper.h
@@ -19,6 +19,7 @@ inline int _strerror_result(char *buffer, char *&out, int r)
 inline int _strerror_result(char *buffer, char *&out, char *r)
 {
   // GNU strerror_r
+  out = r;
   return 0;
 }
 

--- a/src/message_buffer.cpp
+++ b/src/message_buffer.cpp
@@ -1,0 +1,52 @@
+#include <string>
+#include <vector>
+#include <utility>
+#include <iostream>
+
+#include "log.h"
+#include "message.h"
+#include "message_buffer.h"
+
+using std::string;
+using std::move;
+using std::endl;
+
+void MessageBuffer::created(ChannelID channel_id, std::string &&path, const EntryKind &kind)
+{
+  FileSystemPayload payload(channel_id, ACTION_CREATED, kind, move(path), "");
+  Message message(move(payload));
+
+  LOGGER << "Emitting filesystem message " << message << endl;
+
+  messages.push_back(move(message));
+}
+
+void MessageBuffer::modified(ChannelID channel_id, std::string &&path, const EntryKind &kind)
+{
+  FileSystemPayload payload(channel_id, ACTION_MODIFIED, kind, move(path), "");
+  Message message(move(payload));
+
+  LOGGER << "Emitting filesystem message " << message << endl;
+
+  messages.push_back(move(message));
+}
+
+void MessageBuffer::deleted(ChannelID channel_id, std::string &&path, const EntryKind &kind)
+{
+  FileSystemPayload payload(channel_id, ACTION_DELETED, kind, move(path), "");
+  Message message(move(payload));
+
+  LOGGER << "Emitting filesystem message " << message << endl;
+
+  messages.push_back(move(message));
+}
+
+void MessageBuffer::renamed(ChannelID channel_id, std::string &&old_path, std::string &&new_path, const EntryKind &kind)
+{
+  FileSystemPayload payload(channel_id, ACTION_RENAMED, kind, move(old_path), move(new_path));
+  Message message(move(payload));
+
+  LOGGER << "Emitting filesystem message " << message << endl;
+
+  messages.push_back(move(message));
+}

--- a/src/message_buffer.h
+++ b/src/message_buffer.h
@@ -1,0 +1,67 @@
+#ifndef MESSAGE_BUFFER_H
+#define MESSAGE_BUFFER_H
+
+#include <string>
+#include <vector>
+#include <utility>
+
+#include "message.h"
+
+class MessageBuffer {
+public:
+  typedef std::vector<Message>::iterator iter;
+
+  void created(ChannelID channel_id, std::string &&path, const EntryKind &kind);
+
+  void modified(ChannelID channel_id, std::string &&path, const EntryKind &kind);
+
+  void deleted(ChannelID channel_id, std::string &&path, const EntryKind &kind);
+
+  void renamed(ChannelID channel_id, std::string &&old_path, std::string &&new_path, const EntryKind &kind);
+
+  MessageBuffer::iter begin() { return messages.begin(); }
+
+  MessageBuffer::iter end() { return messages.end(); }
+
+  bool empty() { return messages.empty(); }
+
+private:
+  std::vector<Message> messages;
+};
+
+class ChannelMessageBuffer {
+public:
+  ChannelMessageBuffer(ChannelID channel_id) : channel_id{channel_id} {};
+
+  void created(std::string &&path, const EntryKind &kind)
+  {
+    buffer.created(channel_id, std::move(path), kind);
+  }
+
+  void modified(std::string &&path, const EntryKind &kind)
+  {
+    buffer.modified(channel_id, std::move(path), kind);
+  }
+
+  void deleted(std::string &&path, const EntryKind &kind)
+  {
+    buffer.deleted(channel_id, std::move(path), kind);
+  }
+
+  void renamed(std::string &&old_path, std::string &&new_path, const EntryKind &kind)
+  {
+    buffer.renamed(channel_id, std::move(old_path), std::move(new_path), kind);
+  }
+
+  MessageBuffer::iter begin() { return buffer.begin(); }
+
+  MessageBuffer::iter end() { return buffer.end(); }
+
+  bool empty() { return buffer.empty(); }
+
+private:
+  ChannelID channel_id;
+  MessageBuffer buffer;
+};
+
+#endif

--- a/src/result.h
+++ b/src/result.h
@@ -137,7 +137,7 @@ public:
     return Result<U>::make_ok(std::move(value));
   }
 
-  Result<V> &accumulate(Result<V> &&sub_result)
+  Result<V> &operator&=(Result<V> &&sub_result)
   {
     if (is_error() != sub_result.is_error() || sub_result.is_ok()) {
       clear();

--- a/src/result.h
+++ b/src/result.h
@@ -137,6 +137,18 @@ public:
     return Result<U>::make_ok(std::move(value));
   }
 
+  Result<V> &accumulate(Result<V> &&sub_result)
+  {
+    if (is_error() != sub_result.is_error() || sub_result.is_ok()) {
+      clear();
+      assign(std::move(sub_result));
+    } else if (is_error()) {
+      error += ", " + sub_result.get_error();
+    }
+
+    return *this;
+  }
+
 private:
   Result(V &&value) : state{RESULT_OK}, value{std::move(value)}
   {

--- a/src/result.h
+++ b/src/result.h
@@ -127,6 +127,16 @@ public:
     return Result<U>::make_error(prefix + get_error());
   }
 
+  template < class U >
+  Result<U> propagate(U &&value, const std::string &prefix = "") const
+  {
+    if (state == RESULT_ERROR) {
+      return propagate<U>(prefix);
+    }
+
+    return Result<U>::make_ok(std::move(value));
+  }
+
 private:
   Result(V &&value) : state{RESULT_OK}, value{std::move(value)}
   {

--- a/src/worker/linux/cookie_jar.cpp
+++ b/src/worker/linux/cookie_jar.cpp
@@ -1,0 +1,138 @@
+#include <string>
+#include <map>
+#include <deque>
+#include <utility>
+#include <memory>
+#include <sys/types.h>
+
+#include "../../message.h"
+#include "../../message_buffer.h"
+#include "cookie_jar.h"
+
+using std::string;
+using std::move;
+using std::unique_ptr;
+
+Cookie::Cookie(ChannelID channel_id, std::string &&from_path, EntryKind kind) :
+  channel_id{channel_id},
+  from_path(move(from_path)),
+  kind{kind}
+{
+  //
+}
+
+Cookie::Cookie(Cookie &&other) :
+  channel_id{other.channel_id},
+  from_path(move(other.from_path)),
+  kind{kind}
+{
+  //
+}
+
+void CookieBatch::moved_from(
+  MessageBuffer &messages,
+  ChannelID channel_id,
+  uint32_t cookie,
+  string &&old_path,
+  EntryKind kind)
+{
+  auto existing = from_paths.find(cookie);
+  if (existing != from_paths.end()) {
+    // Duplicate IN_MOVED_FROM cookie.
+    // Resolve the old one as a deletion.
+    Cookie dup(move(existing->second));
+    messages.deleted(dup.get_channel_id(), move(dup.get_from_path()), dup.get_kind());
+    from_paths.erase(existing);
+  }
+
+  Cookie c(channel_id, move(old_path), kind);
+  from_paths.emplace(cookie, move(c));
+}
+
+unique_ptr<Cookie> CookieBatch::yoink(uint32_t cookie)
+{
+  auto from = from_paths.find(cookie);
+  if (from == from_paths.end()) {
+    return unique_ptr<Cookie>(nullptr);
+  }
+
+  unique_ptr<Cookie> c(new Cookie(move(from->second)));
+  from_paths.erase(from);
+  return c;
+}
+
+void CookieBatch::flush(MessageBuffer &messages)
+{
+  for (auto &pair : from_paths) {
+    Cookie dup(move(pair.second));
+    messages.deleted(dup.get_channel_id(), move(dup.get_from_path()), dup.get_kind());
+  }
+  from_paths.clear();
+}
+
+CookieJar::CookieJar(unsigned int max_batches) :
+  batches(max_batches)
+{
+  //
+}
+
+void CookieJar::moved_from(
+  MessageBuffer &messages,
+  ChannelID channel_id,
+  uint32_t cookie,
+  std::string &&old_path,
+  EntryKind kind)
+{
+  if (batches.empty()) return;
+
+  batches.back().moved_from(messages, channel_id, cookie, move(old_path), kind);
+}
+
+void CookieJar::moved_to(
+  MessageBuffer &messages,
+  ChannelID channel_id,
+  uint32_t cookie,
+  std::string &&new_path,
+  EntryKind kind)
+{
+  unique_ptr<Cookie> from;
+  for (auto &batch : batches) {
+    unique_ptr<Cookie> found = batch.yoink(cookie);
+    if (found) {
+      if (from) {
+        // Multiple IN_MOVED_FROM results.
+        // Report deletions for all but the most recent.
+        messages.deleted(from->get_channel_id(), move(from->get_from_path()), from->get_kind());
+      }
+
+      from = move(found);
+    }
+  }
+
+  if (!from) {
+    // Unmatched IN_MOVED_TO.
+    // Resolve it as a creation.
+    messages.created(channel_id, move(new_path), kind);
+    return;
+  }
+
+  if (from->get_channel_id() != channel_id || kinds_are_different(from->get_kind(), kind)) {
+    // Existing IN_MOVED_FROM with this cookie does not match.
+    // Resolve it as a deletion/creation pair.
+    messages.deleted(from->get_channel_id(), move(from->get_from_path()), from->get_kind());
+    messages.created(channel_id, move(new_path), kind);
+    return;
+  }
+
+  messages.renamed(channel_id, move(from->get_from_path()), move(new_path), kind);
+}
+
+void CookieJar::flush_oldest_batch(MessageBuffer &messages)
+{
+  if (batches.empty()) return;
+  if (batches.back().empty()) return;
+
+  batches.front().flush(messages);
+  batches.pop_front();
+  batches.emplace_back(CookieBatch());
+}

--- a/src/worker/linux/cookie_jar.cpp
+++ b/src/worker/linux/cookie_jar.cpp
@@ -24,7 +24,7 @@ Cookie::Cookie(ChannelID channel_id, std::string &&from_path, EntryKind kind) :
 Cookie::Cookie(Cookie &&other) :
   channel_id{other.channel_id},
   from_path(move(other.from_path)),
-  kind{kind}
+  kind{other.kind}
 {
   //
 }

--- a/src/worker/linux/cookie_jar.cpp
+++ b/src/worker/linux/cookie_jar.cpp
@@ -130,7 +130,6 @@ void CookieJar::moved_to(
 void CookieJar::flush_oldest_batch(MessageBuffer &messages)
 {
   if (batches.empty()) return;
-  if (batches.back().empty()) return;
 
   batches.front().flush(messages);
   batches.pop_front();

--- a/src/worker/linux/cookie_jar.h
+++ b/src/worker/linux/cookie_jar.h
@@ -11,6 +11,8 @@
 #include "../../message.h"
 #include "../../message_buffer.h"
 
+// Remember a path that was observed in an IN_MOVED_FROM inotify event until its corresponding IN_MOVED_TO event
+// is observed, or until it times out.
 class Cookie {
 public:
   Cookie(ChannelID channel_id, std::string &&from_path, EntryKind kind);
@@ -21,11 +23,10 @@ public:
 
   const ChannelID &get_channel_id() const { return channel_id; }
 
+  // Take possession of the absolute path from this event.
   std::string get_from_path() { return std::string(std::move(from_path)); }
 
   const EntryKind &get_kind() { return kind; }
-
-  bool is_null() const { return channel_id == NULL_CHANNEL_ID; }
 
 private:
   const ChannelID channel_id;
@@ -33,8 +34,13 @@ private:
   const EntryKind kind;
 };
 
+// Collection of Cookies observed from rename events within a single cycle of inotify events. Batches are used to
+// age off rename events that haven't been matched after a fixed number of inotify deliveries.
 class CookieBatch {
 public:
+
+  // Insert a new Cookie to eventually match an IN_MOVED_FROM event. If an existing Cookie already exists for this
+  // cookie value, immediately age the old Cookie off and buffer a deletion event.
   void moved_from(
     MessageBuffer &messages,
     ChannelID channel_id,
@@ -43,8 +49,11 @@ public:
     EntryKind kind
   );
 
+  // Remove a Cookie from this batch that has the specified cookie value. Return nullptr instead if no such cookie
+  // exists.
   std::unique_ptr<Cookie> yoink(uint32_t cookie);
 
+  // Age off all Cookies within this batch by buffering them as deletion events.
   void flush(MessageBuffer &messages);
 
   bool empty() const { return from_paths.empty(); }
@@ -53,14 +62,29 @@ private:
   std::map<uint32_t, Cookie> from_paths;
 };
 
+// Associate IN_MOVED_FROM and IN_MOVED_TO events from inotify received within a configurable number of consecutive
+// notification cycles. The CookieJar contains a fixed number of CookieBatches that contain unmatched IN_MOVED_FROM
+// events collected within a single notification cycle. As more notifications arrive, events that remain unmatched
+// are aged off and emitted as deletion events.
 class CookieJar {
 public:
+
+  // Construct a CookieJar capable of correlating rename events across `max_batches` consecutive inotify event cycles.
+  // Specifying a higher number of batches improves the watcher's ability to match rename events that occur at
+  // high rates, at the cost of increasing memory usage and the latency of delete events delivered when an entry
+  // is renamed outside of a watched directory. If `max_batches` is 0, _no_ rename correlation will be done at
+  // all; all renames will be emitted as create/delete pairs instead. If `max_batches` is 1, only rename events
+  // that arrive within the same notification cycle will be caught, but deletion events will be delivered with
+  // no additional latency. The default of 2 correlates rename events across consecutive notification cycles but
+  // no further.
   CookieJar(unsigned int max_batches = 2);
+
   CookieJar(const CookieJar &other) = delete;
   CookieJar(CookieJar &&other) = delete;
   CookieJar &operator=(const CookieJar &other) = delete;
   CookieJar &operator=(CookieJar &&other) = delete;
 
+  // Observe an IN_MOVED_FROM event by adding a Cookie to the freshest CookieBatch.
   void moved_from(
     MessageBuffer &messages,
     ChannelID channel_id,
@@ -69,6 +93,10 @@ public:
     EntryKind kind
   );
 
+  // Observe an IN_MOVED_TO event. Search the current CookieBatches for a recent IN_MOVED_FROM event with a matching
+  // `cookie` value. If no match is found, emit a creation event for the entry. If a match is found but the channel
+  // or entry kind don't match, emit a delete/create event pair for the old and new entries. Otherwise, emit the
+  // successfully correlated rename event.
   void moved_to(
     MessageBuffer &messages,
     ChannelID channel_id,
@@ -77,6 +105,8 @@ public:
     EntryKind kind
   );
 
+  // Buffer deletion events for any Cookies that have not been matched within `max_batches` CookieBatches. Add a
+  // fresh CookieBatch to capture the next cycle of rename events.
   void flush_oldest_batch(MessageBuffer &messages);
 
 private:

--- a/src/worker/linux/cookie_jar.h
+++ b/src/worker/linux/cookie_jar.h
@@ -1,0 +1,86 @@
+#ifndef COOKIE_JAR
+#define COOKIE_JAR
+
+#include <string>
+#include <map>
+#include <deque>
+#include <utility>
+#include <memory>
+#include <sys/types.h>
+
+#include "../../message.h"
+#include "../../message_buffer.h"
+
+class Cookie {
+public:
+  Cookie(ChannelID channel_id, std::string &&from_path, EntryKind kind);
+  Cookie(Cookie &&other);
+  Cookie(const Cookie &other) = delete;
+  Cookie &operator=(Cookie &&cookie) = delete;
+  Cookie &operator=(const Cookie &other) = delete;
+
+  const ChannelID &get_channel_id() const { return channel_id; }
+
+  std::string get_from_path() { return std::string(std::move(from_path)); }
+
+  const EntryKind &get_kind() { return kind; }
+
+  bool is_null() const { return channel_id == NULL_CHANNEL_ID; }
+
+private:
+  const ChannelID channel_id;
+  std::string from_path;
+  const EntryKind kind;
+};
+
+class CookieBatch {
+public:
+  void moved_from(
+    MessageBuffer &messages,
+    ChannelID channel_id,
+    uint32_t cookie,
+    std::string &&old_path,
+    EntryKind kind
+  );
+
+  std::unique_ptr<Cookie> yoink(uint32_t cookie);
+
+  void flush(MessageBuffer &messages);
+
+  bool empty() const { return from_paths.empty(); }
+
+private:
+  std::map<uint32_t, Cookie> from_paths;
+};
+
+class CookieJar {
+public:
+  CookieJar(unsigned int max_batches = 2);
+  CookieJar(const CookieJar &other) = delete;
+  CookieJar(CookieJar &&other) = delete;
+  CookieJar &operator=(const CookieJar &other) = delete;
+  CookieJar &operator=(CookieJar &&other) = delete;
+
+  void moved_from(
+    MessageBuffer &messages,
+    ChannelID channel_id,
+    uint32_t cookie,
+    std::string &&old_path,
+    EntryKind kind
+  );
+
+  void moved_to(
+    MessageBuffer &messages,
+    ChannelID channel_id,
+    uint32_t cookie,
+    std::string &&new_path,
+    EntryKind kind
+  );
+
+  void flush_oldest_batch(MessageBuffer &messages);
+
+private:
+  std::deque<CookieBatch> batches;
+};
+
+#endif

--- a/src/worker/linux/linux_worker_platform.cpp
+++ b/src/worker/linux/linux_worker_platform.cpp
@@ -64,9 +64,9 @@ public:
         Result<> r = registry.consume(messages, jar, side);
 
         if (!messages.empty()) {
-          r.accumulate(emit_all(messages.begin(), messages.end()));
+          r &= emit_all(messages.begin(), messages.end());
         }
-        r.accumulate(side.enact_in(&registry));
+        r &= side.enact_in(&registry);
 
         if (r.is_error()) return r;
       }

--- a/src/worker/linux/linux_worker_platform.cpp
+++ b/src/worker/linux/linux_worker_platform.cpp
@@ -48,11 +48,11 @@ public:
       }
 
       if (to_poll[0].revents & (POLLIN | POLLERR)) {
-        Result<> hr = handle_commands();
-        if (hr.is_error()) return hr;
-
         Result<> cr = pipe.consume();
         if (cr.is_error()) return cr;
+
+        Result<> hr = handle_commands();
+        if (hr.is_error()) return hr;
       }
 
       if (to_poll[1].revents & (POLLIN | POLLERR)) {

--- a/src/worker/linux/linux_worker_platform.cpp
+++ b/src/worker/linux/linux_worker_platform.cpp
@@ -9,6 +9,7 @@
 #include "../../result.h"
 #include "../../helper/linux/helper.h"
 #include "pipe.h"
+#include "cookie_jar.h"
 #include "watch_registry.h"
 
 using std::string;
@@ -58,7 +59,7 @@ public:
       if (to_poll[1].revents & (POLLIN | POLLERR)) {
         MessageBuffer messages;
 
-        Result<> cr = registry.consume(messages);
+        Result<> cr = registry.consume(messages, jar);
         if (!messages.empty()) {
           emit_all(messages.begin(), messages.end());
         }
@@ -87,6 +88,7 @@ public:
 private:
   Pipe pipe;
   WatchRegistry registry;
+  CookieJar jar;
 };
 
 unique_ptr<WorkerPlatform> WorkerPlatform::for_worker(WorkerThread *thread)

--- a/src/worker/linux/linux_worker_platform.cpp
+++ b/src/worker/linux/linux_worker_platform.cpp
@@ -16,6 +16,7 @@
 using std::string;
 using std::unique_ptr;
 
+// Platform-specific worker implementation for Linux systems.
 class LinuxWorkerPlatform : public WorkerPlatform {
 public:
   LinuxWorkerPlatform(WorkerThread *thread) :
@@ -25,11 +26,13 @@ public:
     //
   };
 
+  // Inform the listen() loop that one or more commands are waiting from the main thread.
   Result<> wake() override
   {
     return pipe.signal();
   }
 
+  // Main event loop. Use poll(2) to wait on I/O from either the Pipe or inotify events.
   Result<> listen() override
   {
     pollfd to_poll[2];
@@ -75,6 +78,7 @@ public:
     return error_result("Polling loop exited unexpectedly");
   }
 
+  // Recursively watch a directory tree.
   Result<bool> handle_add_command(
     const CommandID command,
     const ChannelID channel,
@@ -83,6 +87,7 @@ public:
     return registry.add(channel, move(root_path), true).propagate(true);
   }
 
+  // Unwatch a directory tree.
   Result<bool> handle_remove_command(
     const CommandID command,
     const ChannelID channel) override

--- a/src/worker/linux/pipe.h
+++ b/src/worker/linux/pipe.h
@@ -6,15 +6,23 @@
 #include "../../result.h"
 #include "../../errable.h"
 
+// RAII wrapper for a Linux pipe created with pipe(2). We don't care about the actual data transmitted.
 class Pipe : public SyncErrable {
 public:
+
+  // Construct a new Pipe identified in Result<> errors with a specified name.
   Pipe(const std::string &name);
+
+  // Deallocate and close() the underlying pipe file descriptor.
   ~Pipe();
 
+  // Write a byte to the pipe to inform readers that data is available.
   Result<> signal();
 
+  // Read and discard all data waiting on the pipe to prepare for a new signal.
   Result<> consume();
 
+  // Access the file descriptor that should be polled for data.
   int get_read_fd() const { return read_fd; }
 
 private:

--- a/src/worker/linux/side_effect.cpp
+++ b/src/worker/linux/side_effect.cpp
@@ -19,7 +19,7 @@ Result<> SideEffect::enact_in(WatchRegistry *registry)
 {
   Result<> r = ok_result();
   for (Subdirectory &subdir : subdirectories) {
-    r.accumulate(registry->add(subdir.channel_id, subdir.path, true));
+    r &= registry->add(subdir.channel_id, subdir.path, true);
   }
   return r;
 }

--- a/src/worker/linux/side_effect.cpp
+++ b/src/worker/linux/side_effect.cpp
@@ -1,0 +1,25 @@
+#include <string>
+#include <vector>
+#include <utility>
+
+#include "../../message.h"
+#include "../../result.h"
+#include "watch_registry.h"
+#include "side_effect.h"
+
+using std::string;
+using std::move;
+
+void SideEffect::track_subdirectory(string subdir, ChannelID channel_id)
+{
+  subdirectories.emplace_back(move(subdir), channel_id);
+}
+
+Result<> SideEffect::enact_in(WatchRegistry *registry)
+{
+  Result<> r = ok_result();
+  for (Subdirectory &subdir : subdirectories) {
+    r.accumulate(registry->add(subdir.channel_id, subdir.path, true));
+  }
+  return r;
+}

--- a/src/worker/linux/side_effect.h
+++ b/src/worker/linux/side_effect.h
@@ -12,6 +12,8 @@ class WatchRegistry;
 
 class SideEffect {
 public:
+  SideEffect() = default;
+
   void track_subdirectory(std::string subdir, ChannelID channel_id);
 
   Result<> enact_in(WatchRegistry *registry);

--- a/src/worker/linux/side_effect.h
+++ b/src/worker/linux/side_effect.h
@@ -8,14 +8,19 @@
 #include "../../message.h"
 #include "../../result.h"
 
+// Forward declaration for pointer access.
 class WatchRegistry;
 
+// Record additional actions that should be triggered by inotify events received in the course of a single notification
+// cycle.
 class SideEffect {
 public:
   SideEffect() = default;
 
+  // Recursively watch a newly created subdirectory.
   void track_subdirectory(std::string subdir, ChannelID channel_id);
 
+  // Perform all enqueued actions.
   Result<> enact_in(WatchRegistry *registry);
 
 private:

--- a/src/worker/linux/side_effect.h
+++ b/src/worker/linux/side_effect.h
@@ -1,0 +1,38 @@
+#ifndef SIDE_EFFECT_H
+#define SIDE_EFFECT_H
+
+#include <string>
+#include <vector>
+#include <utility>
+
+#include "../../message.h"
+#include "../../result.h"
+
+class WatchRegistry;
+
+class SideEffect {
+public:
+  void track_subdirectory(std::string subdir, ChannelID channel_id);
+
+  Result<> enact_in(WatchRegistry *registry);
+
+private:
+  SideEffect(const SideEffect &other) = delete;
+  SideEffect(SideEffect &&other) = delete;
+  SideEffect &operator=(const SideEffect &other) = delete;
+  SideEffect &operator=(SideEffect &&other) = delete;
+
+  struct Subdirectory {
+    Subdirectory(std::string &&path, ChannelID channel_id) : path(std::move(path)), channel_id{channel_id}
+    {
+      //
+    }
+
+    std::string path;
+    ChannelID channel_id;
+  };
+
+  std::vector<Subdirectory> subdirectories;
+};
+
+#endif

--- a/src/worker/linux/watch_registry.cpp
+++ b/src/worker/linux/watch_registry.cpp
@@ -1,0 +1,226 @@
+#include <string>
+#include <utility>
+#include <memory>
+#include <unordered_map>
+#include <set>
+#include <vector>
+#include <iostream>
+#include <sys/inotify.h>
+#include <sys/types.h>
+#include <dirent.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include "../../log.h"
+#include "../../result.h"
+#include "../../message.h"
+#include "../../message_buffer.h"
+#include "../../helper/linux/helper.h"
+#include "watched_directory.h"
+#include "watch_registry.h"
+
+using std::string;
+using std::move;
+using std::endl;
+using std::shared_ptr;
+using std::set;
+using std::ostream;
+
+static ostream &operator<<(ostream &out, const inotify_event *event)
+{
+  out << " wd=" << event->wd;
+
+  out << " mask=( ";
+  if (event->mask & IN_ACCESS) out << "IN_ACCESS ";
+  if (event->mask & IN_ATTRIB) out << "IN_ATTRIB ";
+  if (event->mask & IN_CLOSE_WRITE) out << "IN_CLOSE_WRITE ";
+  if (event->mask & IN_CLOSE_NOWRITE) out << "IN_CLOSE_NOWRITE ";
+  if (event->mask & IN_CREATE) out << "IN_CREATE ";
+  if (event->mask & IN_DELETE) out << "IN_DELETE ";
+  if (event->mask & IN_DELETE_SELF) out << "IN_DELETE_SELF ";
+  if (event->mask & IN_MOVE_SELF) out << "IN_MOVE_SELF ";
+  if (event->mask & IN_MOVED_FROM) out << "IN_MOVED_FROM ";
+  if (event->mask & IN_MOVED_TO) out << "IN_MOVED_TO ";
+  if (event->mask & IN_OPEN) out << "IN_OPEN ";
+  if (event->mask & IN_IGNORED) out << "IN_IGNORED ";
+  if (event->mask & IN_Q_OVERFLOW) out << "IN_Q_OVERFLOW ";
+  if (event->mask & IN_UNMOUNT) out << "IN_UNMOUNT ";
+  out << " ) cookie=" << event->cookie;
+  out << " len=" << event->len;
+  if (event->len > 0) {
+    out << " name=" << event->name;
+  }
+
+  return out;
+}
+
+WatchRegistry::WatchRegistry() :
+  Errable("inotify watcher registry")
+{
+  inotify_fd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+
+  if (inotify_fd == -1) {
+    report_error(errno_result("Unable to initialize inotify"));
+  }
+}
+
+WatchRegistry::~WatchRegistry()
+{
+  if (inotify_fd > 0) {
+    close(inotify_fd);
+  }
+}
+
+Result<> WatchRegistry::add(ChannelID channel_id, string root, bool recursive)
+{
+  if (!is_healthy()) return health_err_result<>();
+
+  uint32_t mask =  IN_ATTRIB | IN_CREATE | IN_DELETE | IN_DELETE_SELF | IN_MODIFY | IN_MOVE_SELF |
+      IN_MOVED_FROM | IN_MOVED_TO | IN_DONT_FOLLOW | IN_EXCL_UNLINK;
+  if (recursive) mask |= IN_ONLYDIR;
+
+  LOGGER << "Watching path [" << root << "]." << endl;
+  int wd = inotify_add_watch(inotify_fd, root.c_str(), mask);
+  if (wd == -1) {
+    // TODO: signal a revert to polling on ENOSPC
+    return errno_result("Unable to watch directory");
+  }
+
+  LOGGER << "Assigned watch descriptor " << wd << "." << endl;
+
+  string root_dup(root);
+  shared_ptr<WatchedDirectory> watched_dir(new WatchedDirectory(wd, channel_id, move(root_dup)));
+
+  by_wd.insert({wd, watched_dir});
+  by_channel.insert({channel_id, watched_dir});
+
+  if (recursive) {
+    LOGGER << "Recursing into directory." << endl;
+    DIR *dir = opendir(root.c_str());
+    if (dir == NULL) {
+      int open_errno = errno;
+      if (open_errno != EACCES && open_errno != ENOENT && open_errno != ENOTDIR) {
+        return errno_result("Unable to recurse into directory " + root, open_errno);
+      }
+    } else {
+      errno = 0;
+      dirent *entry = readdir(dir);
+      while (entry != NULL) {
+        string basename(entry->d_name);
+
+        LOGGER << "Processing entry " << basename << "." << endl;
+
+        if (basename == "." || basename == "..") {
+          entry = readdir(dir);
+          continue;
+        }
+        string subdir = root + "/" + basename;
+
+#ifndef _DIRENT_HAVE_D_TYPE
+        if (entry->d_type == DT_DIR || entry->d_type == DT_UNKNOWN) {
+          LOGGER << "Recursing into [" << subdir << "]." << endl;
+          Result<> add_r = add(channel_id, subdir, true);
+          if (add_r.is_error()) {
+            LOGGER << "Unable to recurse into " << subdir << ": " << add_r << "." << endl;
+          }
+        }
+#else
+        LOGGER << "Recursing into [" << subdir << "]." << endl;
+        Result<> add_r = add(channel_id, subdir, true);
+        if (add_r.is_error()) {
+          LOGGER << "Unable to recurse into " << subdir << ": " << add_r << "." << endl;
+        }
+#endif
+
+        entry = readdir(dir);
+      }
+      if (errno != 0) {
+        return errno_result("Unable to iterate entries of directory " + root);
+      }
+    }
+  }
+
+  return ok_result();
+}
+
+Result<> WatchRegistry::remove(ChannelID channel_id)
+{
+  if (!is_healthy()) return health_err_result<>();
+
+  auto its = by_channel.equal_range(channel_id);
+  set<int> wds;
+  for (auto it = its.first; it != its.second; ++it) {
+    wds.insert(it->second->get_descriptor());
+  }
+
+  by_channel.erase(channel_id);
+  for (auto &&wd : wds) {
+    by_wd.erase(wd);
+  }
+
+  LOGGER << "Channel " << channel_id << " has been unwatched." << endl;
+
+  return ok_result();
+}
+
+Result<> WatchRegistry::consume(MessageBuffer &messages)
+{
+  if (!is_healthy()) return health_err_result<>();
+
+  LOGGER << "Consuming inotify events." << endl;
+
+  const size_t BUFSIZE = 2048 * sizeof(inotify_event);
+  char buf[BUFSIZE] __attribute__ ((aligned(__alignof__(struct inotify_event))));
+  ssize_t result = 0;
+
+  while (true) {
+    result = read(inotify_fd, &buf, BUFSIZE);
+
+    if (result < 0) {
+      int read_errno = errno;
+
+      if (read_errno == EAGAIN || read_errno == EWOULDBLOCK) {
+        // Nothing left to read.
+        LOGGER << "Nothing left to read." << endl;
+        return ok_result();
+      }
+
+      return errno_result<>("Unable to read inotify events", read_errno);
+    }
+
+    if (result == 0) {
+      LOGGER << "EOF." << endl;
+      return ok_result();
+    }
+
+    // At least one inotify event to read.
+    char *current = buf;
+    inotify_event *event = nullptr;
+    while (current < buf + result) {
+      event = reinterpret_cast<inotify_event*>(current);
+      current += sizeof(inotify_event) + event->len;
+
+      LOGGER << "Received inotify event: " << event << "." << endl;
+
+      if (event->mask & IN_Q_OVERFLOW) {
+        LOGGER << "Event queue overflow. Some events have been missed." << endl;
+        continue;
+      }
+
+      auto its = by_wd.equal_range(event->wd);
+      if (its.first == by_wd.end() && its.second == by_wd.end()) {
+        LOGGER << "Received event for unknown watch descriptor " << event->wd << "." << endl;
+        continue;
+      }
+
+      for (auto it = its.first; it != its.second; ++it) {
+        shared_ptr<WatchedDirectory> watched_directory = it->second;
+
+        Result<> r = watched_directory->accept_event(messages, *event);
+        if (r.is_error()) {
+          LOGGER << "Unable to process event: " << r << "." << endl;
+        }
+      }
+    }
+  }
+}

--- a/src/worker/linux/watch_registry.h
+++ b/src/worker/linux/watch_registry.h
@@ -1,0 +1,34 @@
+#ifndef WATCHER_REGISTRY_H
+#define WATCHER_REGISTRY_H
+
+#include <string>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+#include <sys/inotify.h>
+
+#include "../../errable.h"
+#include "../../result.h"
+#include "../../message_buffer.h"
+#include "watched_directory.h"
+
+class WatchRegistry : public Errable {
+public:
+  WatchRegistry();
+  ~WatchRegistry();
+
+  Result<> add(ChannelID channel_id, std::string root, bool recursive);
+
+  Result<> remove(ChannelID channel_id);
+
+  Result<> consume(MessageBuffer &messages);
+
+  int get_read_fd() { return inotify_fd; }
+
+private:
+  int inotify_fd;
+  std::unordered_multimap<int, std::shared_ptr<WatchedDirectory>> by_wd;
+  std::unordered_multimap<ChannelID, std::shared_ptr<WatchedDirectory>> by_channel;
+};
+
+#endif

--- a/src/worker/linux/watch_registry.h
+++ b/src/worker/linux/watch_registry.h
@@ -14,17 +14,32 @@
 #include "side_effect.h"
 #include "watched_directory.h"
 
+// Manage the set of open inotify watch descriptors.
 class WatchRegistry : public Errable {
 public:
+
+  // Initialize inotify. Enter an error state if inotify initialization fails.
   WatchRegistry();
+
+  // Stop inotify and release all kernel resources associated with it.
   ~WatchRegistry();
 
+  // Begin watching a root path. If `recursive` is `true`, recursively watch all
+  // subdirectories as well.
+  //
+  // `root` must name a directory if `recursive` is `true`.
   Result<> add(ChannelID channel_id, std::string root, bool recursive);
 
+  // Uninstall inotify watchers used to deliver events on a specified channel.
   Result<> remove(ChannelID channel_id);
 
+  // Interpret all inotify events created since the previous call to consume(), until the
+  // read() call would block. Buffer messages corresponding to each inotify event. Use the
+  // CookieJar to match pairs of rename events and the SideEffect to enqueue side effects.
   Result<> consume(MessageBuffer &messages, CookieJar &jar, SideEffect &side);
 
+  // Return the file descriptor that should be polled to wake up when inotify events are
+  // available.
   int get_read_fd() { return inotify_fd; }
 
 private:

--- a/src/worker/linux/watch_registry.h
+++ b/src/worker/linux/watch_registry.h
@@ -10,6 +10,7 @@
 #include "../../errable.h"
 #include "../../result.h"
 #include "../../message_buffer.h"
+#include "cookie_jar.h"
 #include "watched_directory.h"
 
 class WatchRegistry : public Errable {
@@ -21,7 +22,7 @@ public:
 
   Result<> remove(ChannelID channel_id);
 
-  Result<> consume(MessageBuffer &messages);
+  Result<> consume(MessageBuffer &messages, CookieJar &jar);
 
   int get_read_fd() { return inotify_fd; }
 

--- a/src/worker/linux/watch_registry.h
+++ b/src/worker/linux/watch_registry.h
@@ -11,6 +11,7 @@
 #include "../../result.h"
 #include "../../message_buffer.h"
 #include "cookie_jar.h"
+#include "side_effect.h"
 #include "watched_directory.h"
 
 class WatchRegistry : public Errable {
@@ -22,7 +23,7 @@ public:
 
   Result<> remove(ChannelID channel_id);
 
-  Result<> consume(MessageBuffer &messages, CookieJar &jar);
+  Result<> consume(MessageBuffer &messages, CookieJar &jar, SideEffect &side);
 
   int get_read_fd() { return inotify_fd; }
 

--- a/src/worker/linux/watched_directory.cpp
+++ b/src/worker/linux/watched_directory.cpp
@@ -1,0 +1,86 @@
+#include <string>
+#include <utility>
+#include <vector>
+#include <sys/inotify.h>
+
+#include "../../result.h"
+#include "../../message.h"
+#include "../../message_buffer.h"
+#include "watched_directory.h"
+
+using std::string;
+using std::vector;
+using std::move;
+
+WatchedDirectory::WatchedDirectory(int wd, ChannelID channel_id, string &&directory) :
+  wd{wd},
+  channel_id{channel_id},
+  directory{move(directory)}
+{
+  //
+}
+
+Result<> WatchedDirectory::accept_event(MessageBuffer &buffer, const inotify_event &event)
+{
+  EntryKind kind = event.mask & IN_ISDIR ? KIND_DIRECTORY : KIND_FILE;
+  string path = get_absolute_path(event);
+
+  if (event.mask & IN_CREATE) {
+    // create entry inside directory
+
+    if (kind == KIND_DIRECTORY) {
+      // subdirectory created
+      // TODO: create subdirectory watcher
+      buffer.created(channel_id, move(path), kind);
+      return ok_result();
+    } else {
+      // file created
+      buffer.created(channel_id, move(path), kind);
+      return ok_result();
+    }
+  }
+
+  if (event.mask & IN_DELETE) {
+    // delete entry inside directory
+    buffer.deleted(channel_id, move(path), kind);
+    return ok_result();
+  }
+
+  if (event.mask & (IN_MODIFY | IN_ATTRIB)) {
+    // modify entry inside directory or attribute change for directory or entry inside directory
+    buffer.modified(channel_id, move(path), kind);
+  }
+
+  if (event.mask & (IN_DELETE_SELF | IN_UNMOUNT)) {
+    buffer.deleted(channel_id, move(path), kind);
+  }
+
+  if (event.mask & IN_MOVE_SELF) {
+    // directory itself was renamed
+    // TODO note old name and cookie
+  }
+
+  if (event.mask & IN_MOVED_FROM) {
+    // rename source for directory or entry inside directory
+    // TODO note new name and cookie
+  }
+
+  if (event.mask & IN_MOVED_TO) {
+    // rename destination for directory or entry inside directory
+    // TODO note new name and cookie
+  }
+
+  // IN_IGNORED
+
+  return ok_result();
+}
+
+string WatchedDirectory::get_absolute_path(const inotify_event &event)
+{
+  if (event.len == 0) {
+    // Return a copy because the path gets moved
+    return string(directory);
+  }
+
+  return string(event.name);
+}

--- a/src/worker/linux/watched_directory.cpp
+++ b/src/worker/linux/watched_directory.cpp
@@ -82,5 +82,5 @@ string WatchedDirectory::get_absolute_path(const inotify_event &event)
     return string(directory);
   }
 
-  return string(event.name);
+  return string(directory + "/" + event.name);
 }

--- a/src/worker/linux/watched_directory.cpp
+++ b/src/worker/linux/watched_directory.cpp
@@ -77,6 +77,9 @@ Result<> WatchedDirectory::accept_event(
 
   if (event.mask & IN_MOVED_TO) {
     // rename destination for directory or entry inside directory
+    if (kind == KIND_DIRECTORY) {
+      side.track_subdirectory(path, channel_id);
+    }
     jar.moved_to(buffer, channel_id, event.cookie, move(path), kind);
     return ok_result();
   }

--- a/src/worker/linux/watched_directory.h
+++ b/src/worker/linux/watched_directory.h
@@ -1,0 +1,32 @@
+#ifndef WATCHED_DIRECTORY
+#define WATCHED_DIRECTORY
+
+#include <string>
+#include <vector>
+#include <sys/inotify.h>
+
+#include "../../result.h"
+#include "../../message_buffer.h"
+
+class WatchedDirectory {
+public:
+  WatchedDirectory(int wd, ChannelID channel_id, std::string &&directory);
+
+  Result<> accept_event(MessageBuffer &buffer, const inotify_event &event);
+
+  int get_descriptor() { return wd; }
+
+private:
+  WatchedDirectory(const WatchedDirectory &other) = delete;
+  WatchedDirectory(WatchedDirectory &&other) = delete;
+  WatchedDirectory &operator=(const WatchedDirectory &other) = delete;
+  WatchedDirectory &operator=(WatchedDirectory &&other) = delete;
+
+  std::string get_absolute_path(const inotify_event &event);
+
+  int wd;
+  ChannelID channel_id;
+  std::string directory;
+};
+
+#endif

--- a/src/worker/linux/watched_directory.h
+++ b/src/worker/linux/watched_directory.h
@@ -7,13 +7,14 @@
 
 #include "../../result.h"
 #include "../../message_buffer.h"
+#include "side_effect.h"
 #include "cookie_jar.h"
 
 class WatchedDirectory {
 public:
   WatchedDirectory(int wd, ChannelID channel_id, std::string &&directory);
 
-  Result<> accept_event(MessageBuffer &buffer, CookieJar &jar, const inotify_event &event);
+  Result<> accept_event(MessageBuffer &buffer, CookieJar &jar, SideEffect &side, const inotify_event &event);
 
   int get_descriptor() { return wd; }
 

--- a/src/worker/linux/watched_directory.h
+++ b/src/worker/linux/watched_directory.h
@@ -7,12 +7,13 @@
 
 #include "../../result.h"
 #include "../../message_buffer.h"
+#include "cookie_jar.h"
 
 class WatchedDirectory {
 public:
   WatchedDirectory(int wd, ChannelID channel_id, std::string &&directory);
 
-  Result<> accept_event(MessageBuffer &buffer, const inotify_event &event);
+  Result<> accept_event(MessageBuffer &buffer, CookieJar &jar, const inotify_event &event);
 
   int get_descriptor() { return wd; }
 

--- a/src/worker/linux/watched_directory.h
+++ b/src/worker/linux/watched_directory.h
@@ -10,12 +10,16 @@
 #include "side_effect.h"
 #include "cookie_jar.h"
 
+// Associate resources used to watch inotify events that are delivered with a single watch descriptor.
 class WatchedDirectory {
 public:
   WatchedDirectory(int wd, ChannelID channel_id, std::string &&directory);
 
+  // Interpret a single inotify event. Buffer messages, store or resolve rename Cookies from the CookieJar, and
+  // enqueue SideEffects based on the event's mask.
   Result<> accept_event(MessageBuffer &buffer, CookieJar &jar, SideEffect &side, const inotify_event &event);
 
+  // Access the watch descriptor that corresponds to this directory.
   int get_descriptor() { return wd; }
 
 private:
@@ -24,6 +28,7 @@ private:
   WatchedDirectory &operator=(const WatchedDirectory &other) = delete;
   WatchedDirectory &operator=(WatchedDirectory &&other) = delete;
 
+  // Translate the relative path within an inotify event into an absolute path within this directory.
   std::string get_absolute_path(const inotify_event &event);
 
   int wd;

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -333,7 +333,7 @@ describe('watcher', function () {
         }))
       })
 
-      it('when a file is renamed from inside of the watch root out ^win', async function () {
+      it('when a file is renamed from inside of the watch root out ^windows ^mac', async function () {
         const outsideFile = path.join(fixtureDir, 'file.txt')
         const insideFile = path.join(watchDir, 'file.txt')
         const flagFile = path.join(watchDir, 'flag.txt')

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -126,10 +126,6 @@ describe('watcher', function () {
       let errors, events
 
       beforeEach(async function () {
-        if (!['darwin', 'win32'].includes(process.platform)) {
-          this.skip()
-        }
-
         errors = []
         events = []
 

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -70,14 +70,10 @@ describe('watcher', function () {
 
   describe('watching a directory', function () {
     beforeEach(async function () {
-      if (!['darwin', 'win32'].includes(process.platform)) {
-        this.skip()
-      }
-
       await watcher.configure({mainLog: mainLogFile, workerLog: workerLogFile})
     })
 
-    it('begins receiving events within that directory ^linux', async function () {
+    it('begins receiving events within that directory', async function () {
       let error = null
       const events = []
 
@@ -92,7 +88,7 @@ describe('watcher', function () {
       assert.isNull(error)
     })
 
-    it('can watch multiple directories at once and dispatch events appropriately ^linux', async function () {
+    it('can watch multiple directories at once and dispatch events appropriately', async function () {
       const errors = []
       const eventsA = []
       const eventsB = []
@@ -187,7 +183,7 @@ describe('watcher', function () {
         }
       }
 
-      it('when a file is created ^linux', async function () {
+      it('when a file is created', async function () {
         const createdFile = path.join(watchDir, 'file.txt')
         await fs.writeFile(createdFile, 'contents')
 
@@ -198,7 +194,7 @@ describe('watcher', function () {
         }))
       })
 
-      it('when a file is modified ^linux', async function () {
+      it('when a file is modified', async function () {
         const modifiedFile = path.join(watchDir, 'file.txt')
         await fs.writeFile(modifiedFile, 'initial contents\n')
 
@@ -216,7 +212,7 @@ describe('watcher', function () {
         }))
       })
 
-      it('when a file is renamed ^linux', async function () {
+      it('when a file is renamed', async function () {
         const oldPath = path.join(watchDir, 'old-file.txt')
         await fs.writeFile(oldPath, 'initial contents\n')
 
@@ -239,7 +235,7 @@ describe('watcher', function () {
         }))
       })
 
-      it('when a file is deleted ^linux', async function () {
+      it('when a file is deleted', async function () {
         const deletedPath = path.join(watchDir, 'file.txt')
         await fs.writeFile(deletedPath, 'initial contents\n')
 
@@ -257,7 +253,7 @@ describe('watcher', function () {
         }))
       })
 
-      it('understands coalesced creation and deletion events ^linux ^mac', async function () {
+      it('understands coalesced creation and deletion events ^mac', async function () {
         const deletedPath = path.join(watchDir, 'deleted.txt')
         const recreatedPath = path.join(watchDir, 'recreated.txt')
         const createdPath = path.join(watchDir, 'created.txt')
@@ -282,7 +278,7 @@ describe('watcher', function () {
         ))
       })
 
-      it('correlates rapid file rename events ^linux', async function () {
+      it('correlates rapid file rename events', async function () {
         const oldPath0 = path.join(watchDir, 'old-file-0.txt')
         const oldPath1 = path.join(watchDir, 'old-file-1.txt')
         const oldPath2 = path.join(watchDir, 'old-file-2.txt')
@@ -312,7 +308,7 @@ describe('watcher', function () {
         ))
       })
 
-      it('when a directory is created ^linux', async function () {
+      it('when a directory is created', async function () {
         const subdir = path.join(watchDir, 'subdir')
         await fs.mkdirs(subdir)
 
@@ -321,7 +317,7 @@ describe('watcher', function () {
         ))
       })
 
-      it('when a directory is renamed ^linux', async function () {
+      it('when a directory is renamed', async function () {
         const oldDir = path.join(watchDir, 'subdir')
         const newDir = path.join(watchDir, 'newdir')
 
@@ -336,7 +332,7 @@ describe('watcher', function () {
         ))
       })
 
-      it('when a directory is deleted ^linux', async function () {
+      it('when a directory is deleted', async function () {
         const subdir = path.join(watchDir, 'subdir')
         await fs.mkdirs(subdir)
         await until('directory creation event arrives', eventMatching(
@@ -349,7 +345,7 @@ describe('watcher', function () {
         ))
       })
 
-      it('when a directory is deleted and a file is created in its place ^linux', async function () {
+      it('when a directory is deleted and a file is created in its place', async function () {
         const reusedPath = path.join(watchDir, 'reused')
         await fs.mkdir(reusedPath)
         await until('directory creation event arrives', eventMatching(
@@ -365,7 +361,7 @@ describe('watcher', function () {
         ))
       })
 
-      it('when a directory is deleted and a file is renamed in its place ^linux', async function () {
+      it('when a directory is deleted and a file is renamed in its place', async function () {
         const reusedPath = path.join(watchDir, 'reused')
         const oldFilePath = path.join(watchDir, 'oldfile')
 
@@ -387,7 +383,7 @@ describe('watcher', function () {
         ))
       })
 
-      it('when a directory is renamed and a file is created in its place ^linux', async function () {
+      it('when a directory is renamed and a file is created in its place', async function () {
         const reusedPath = path.join(watchDir, 'reused')
         const newDirPath = path.join(watchDir, 'newdir')
 
@@ -405,7 +401,7 @@ describe('watcher', function () {
         ))
       })
 
-      it('when a directory is renamed and a file is renamed in its place ^linux', async function () {
+      it('when a directory is renamed and a file is renamed in its place', async function () {
         const reusedPath = path.join(watchDir, 'reused')
         const oldFilePath = path.join(watchDir, 'oldfile')
         const newDirPath = path.join(watchDir, 'newdir')
@@ -428,7 +424,7 @@ describe('watcher', function () {
         ))
       })
 
-      it('when a file is deleted and a directory is created in its place ^linux', async function () {
+      it('when a file is deleted and a directory is created in its place', async function () {
         const reusedPath = path.join(watchDir, 'reused')
         await fs.writeFile(reusedPath, 'something\n')
         await until('directory creation event arrives', eventMatching(
@@ -444,7 +440,7 @@ describe('watcher', function () {
         ))
       })
 
-      it('when a file is deleted and a directory is renamed in its place ^linux', async function () {
+      it('when a file is deleted and a directory is renamed in its place', async function () {
         const reusedPath = path.join(watchDir, 'reused')
         const oldDirPath = path.join(watchDir, 'olddir')
 
@@ -466,7 +462,7 @@ describe('watcher', function () {
         ))
       })
 
-      it('when a file is renamed and a directory is created in its place ^linux', async function () {
+      it('when a file is renamed and a directory is created in its place', async function () {
         const reusedPath = path.join(watchDir, 'reused')
         const newFilePath = path.join(watchDir, 'newfile')
 
@@ -484,7 +480,7 @@ describe('watcher', function () {
         ))
       })
 
-      it('when a file is renamed and a directory is renamed in its place ^linux', async function () {
+      it('when a file is renamed and a directory is renamed in its place', async function () {
         const reusedPath = path.join(watchDir, 'reused')
         const oldDirPath = path.join(watchDir, 'olddir')
         const newFilePath = path.join(watchDir, 'newfile')
@@ -511,14 +507,10 @@ describe('watcher', function () {
 
   describe('unwatching a directory', function () {
     beforeEach(async function () {
-      if (!['darwin', 'win32'].includes(process.platform)) {
-        this.skip()
-      }
-
       await watcher.configure({mainLog: mainLogFile, workerLog: workerLogFile})
     })
 
-    it('unwatches a previously watched directory ^linux', async function () {
+    it('unwatches a previously watched directory', async function () {
       let error = null
       const events = []
 
@@ -546,7 +538,7 @@ describe('watcher', function () {
       assert.lengthOf(events, eventCount)
     })
 
-    it('is a no-op if the directory is not being watched ^linux', async function () {
+    it('is a no-op if the directory is not being watched', async function () {
       let error = null
       const sub = await watcher.watch(watchDir, err => (error = err))
       subs.push(sub)

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -333,7 +333,7 @@ describe('watcher', function () {
         }))
       })
 
-      it('when a file is renamed from inside of the watch root out', async function () {
+      it('when a file is renamed from inside of the watch root out ^win', async function () {
         const outsideFile = path.join(fixtureDir, 'file.txt')
         const insideFile = path.join(watchDir, 'file.txt')
         const flagFile = path.join(watchDir, 'flag.txt')


### PR DESCRIPTION
- [x] Handle rename detection.
- [x] Add test cases to verify recursion.
  - [x] Handle recursively added subdirectories.
  - [x] Test renames out of and into watched directories.
  - [x] Ensure that subdirectories that are renamed into a watched directory are also recursively watched.
- [x] Documentation :notebook: 

Fixes #4.