### PR TITLE
Change test case for renames out of the watched root

### DIFF
--- a/src/worker/macos/event_handler.cpp
+++ b/src/worker/macos/event_handler.cpp
@@ -160,13 +160,12 @@ private:
 
     LOGGER << "Entry is no longer present." << endl;
 
-    if (former->is_present()) {
-      if (kinds_are_different(former->get_entry_kind(), current->get_entry_kind())) {
-        // Entry was last seen as a directory, but the latest event has it flagged as a file (or vice versa).
-        // The directory must have been deleted.
-        handler.enqueue_deletion(former->get_path(), former->get_entry_kind());
-      }
-
+    if (former->is_present() && kinds_are_different(former->get_entry_kind(), current->get_entry_kind())) {
+      // Entry was last seen as a directory, but the latest event has it flagged as a file (or vice versa).
+      // The directory must have been deleted.
+      handler.enqueue_deletion(former->get_path(), former->get_entry_kind());
+      handler.enqueue_creation(current->get_path(), current->get_entry_kind());
+    } else {
       // Entry has not been seen before, so we must have missed its creation event.
       handler.enqueue_creation(current->get_path(), current->get_entry_kind());
     }

--- a/src/worker/macos/macos_worker_platform.cpp
+++ b/src/worker/macos/macos_worker_platform.cpp
@@ -234,7 +234,7 @@ public:
     }
 
     LOGGER << "Filesystem event batch of size " << num_events << " completed. "
-      << messages.size() << " message(s) produced." << endl;
+      << plural(messages.size(), "message") << " produced." << endl;
 
     cache.prune();
   }

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -339,7 +339,6 @@ describe('watcher', function () {
         const flagFile = path.join(watchDir, 'flag.txt')
 
         await fs.writeFile(insideFile, 'contents')
-        await fs.rename(insideFile, outsideFile)
 
         await until('the creation event arrives', eventMatching({
           type: 'created',
@@ -347,7 +346,17 @@ describe('watcher', function () {
           oldPath: insideFile
         }))
 
-        await fs.writeFile(flagFile, 'flag')
+        await fs.rename(insideFile, outsideFile)
+        await fs.writeFile(flagFile, 'flag 1')
+
+        await until('the flag file event arrives', eventMatching({
+          type: 'created',
+          kind: 'file',
+          oldPath: flagFile
+        }))
+
+        // Trigger another batch of events on Linux
+        await fs.writeFile(flagFile, 'flag 2')
 
         await until('the deletion event arrives', eventMatching({
           type: 'deleted',

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -341,7 +341,8 @@ describe('watcher', function () {
         await fs.writeFile(insideFile, 'contents')
         await fs.rename(insideFile, outsideFile)
 
-        await until('the original event arrives', eventMatching({
+        await until('the creation event arrives', eventMatching({
+          type: 'created',
           kind: 'file',
           oldPath: insideFile
         }))

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -333,7 +333,7 @@ describe('watcher', function () {
         }))
       })
 
-      it('when a file is renamed from inside of the watch root out ^windows ^mac', async function () {
+      it('when a file is renamed from inside of the watch root out ^windows', async function () {
         const outsideFile = path.join(fixtureDir, 'file.txt')
         const insideFile = path.join(watchDir, 'file.txt')
         const flagFile = path.join(watchDir, 'flag.txt')


### PR DESCRIPTION
MacOS can't handle a collapsed creation and rename event for an entry that's no longer present, because there's no inode to use to correlate it to a corresponding destination rename event (if there is one). Delay the rename event in the failing spec until after the creation event arrives to tease apart the events and give the MacOS platform-specific code a chance to see and handle it.