### PR TITLE
Prepopulate the recent file cache on MacOS

### DIFF
--- a/src/worker/macos/macos_worker_platform.cpp
+++ b/src/worker/macos/macos_worker_platform.cpp
@@ -180,6 +180,8 @@ public:
 
     CFRelease(watch_roots);
     CFRelease(watch_root);
+
+    cache.prepopulate(root_path, 4096);
     return ok_result(true);
   }
 

--- a/src/worker/macos/recent_file_cache.h
+++ b/src/worker/macos/recent_file_cache.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <memory>
 #include <iostream>
+#include <dirent.h>
 #include <sys/stat.h>
 
 #include "../../message.h"
@@ -77,6 +78,8 @@ public:
   std::shared_ptr<StatResult> at_path(const std::string &path, bool file_hint, bool directory_hint);
 
   void prune();
+
+  void prepopulate(const std::string &root, size_t count);
 private:
   std::unordered_map<std::string, std::shared_ptr<PresentEntry>> by_path;
   std::multimap<std::chrono::time_point<std::chrono::steady_clock>, std::shared_ptr<PresentEntry>> by_timestamp;


### PR DESCRIPTION
The MacOS watcher thread uses a recent file cache of stat results to associate the halves of rename events, but it's unable to detect renames from files and directories that existed before the watcher was started. Pre-populate the cache with a bounded number of stat() results (currently 4096) discovered by a breadth-first traversal.