### PR TITLE
Report Windows errors in a more friendly way

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ machine:
 
 dependencies:
   pre:
+  - brew update
   - brew install nvm
   - mkdir -p ${NVM_DIR}
   - echo "source /usr/local/opt/nvm/nvm.sh" >> ~/.bashrc

--- a/src/helper/windows/helper.h
+++ b/src/helper/windows/helper.h
@@ -34,8 +34,14 @@ Result<V> windows_error_result(const std::string &prefix, DWORD error_code)
     NULL // arguments
   );
 
+  std::string msg_str(static_cast<char*>(msg_buffer));
+  // Remove the pesky CRLF and punctuation
+  if (msg_str.size() > 3) {
+    msg_str.erase(msg_str.size() - 3, 3);
+  }
+
   std::ostringstream msg;
-  msg << prefix << " (" << error_code << ") " << (char*) msg_buffer;
+  msg << prefix << " (" << error_code << ") " << msg_str;
   LocalFree(msg_buffer);
 
   return Result<V>::make_error(msg.str());

--- a/src/worker/windows/windows_worker_platform.cpp
+++ b/src/worker/windows/windows_worker_platform.cpp
@@ -204,6 +204,7 @@ public:
 
     // Handle errors.
     if (error_code == ERROR_INVALID_PARAMETER) {
+      LOGGER << "Attempting to revert to a network-friendly buffer size." << endl;
       Result<> resize = sub->use_network_size();
       if (resize.is_error()) return resize;
 
@@ -274,8 +275,6 @@ private:
       if (attr_err != ERROR_FILE_NOT_FOUND && attr_err != ERROR_PATH_NOT_FOUND) {
         return windows_error_result<>("GetFileAttributesW failed", attr_err);
       }
-      Result<> t = windows_error_result<>("GetFileAttributesW reports");
-      LOGGER << t << endl;
     } else if (attrs & FILE_ATTRIBUTE_DIRECTORY) {
       kind = KIND_DIRECTORY;
     } else {


### PR DESCRIPTION
Windows' `GetLastError()` appends a `.<CRLF>` to every error message, which looks ugly in the logs. Manually clean it up a little.