### PR TITLE
Revert to polling when a Windows filesystem does not support the change API

### DIFF
--- a/src/worker/windows/subscription.cpp
+++ b/src/worker/windows/subscription.cpp
@@ -42,13 +42,14 @@ Subscription::~Subscription()
   CloseHandle(root);
 }
 
-Result<> Subscription::schedule(LPOVERLAPPED_COMPLETION_ROUTINE fn)
+Result<bool> Subscription::schedule(LPOVERLAPPED_COMPLETION_ROUTINE fn)
 {
   if (terminating) {
     LOGGER << "Declining to schedule a new change callback for channel " << channel
       << " because the subscription is terminating." << endl;
-    return ok_result();
+    return ok_result(true);
   }
+
   LOGGER << "Scheduling the next change callback for channel " << channel << "." << endl;
 
   int success = ReadDirectoryChangesW(
@@ -63,11 +64,18 @@ Result<> Subscription::schedule(LPOVERLAPPED_COMPLETION_ROUTINE fn)
     &overlapped, // overlapped
     fn // completion routine
   );
+
   if (!success) {
-    return windows_error_result<>("Unable to subscribe to filesystem events");
+    DWORD last_error = GetLastError();
+    if (last_error == ERROR_INVALID_FUNCTION) {
+      // Filesystem does not support change events.
+      return ok_result(false);
+    }
+
+    return windows_error_result<bool>("Unable to subscribe to filesystem events", last_error);
   }
 
-  return ok_result();
+  return ok_result(true);
 }
 
 Result<> Subscription::use_network_size()

--- a/src/worker/windows/subscription.h
+++ b/src/worker/windows/subscription.h
@@ -21,7 +21,7 @@ public:
 
   ~Subscription();
 
-  Result<> schedule(LPOVERLAPPED_COMPLETION_ROUTINE fn);
+  Result<bool> schedule(LPOVERLAPPED_COMPLETION_ROUTINE fn);
 
   Result<> use_network_size();
 


### PR DESCRIPTION
I wasn't actually able to make this fail with a Samba mount from my Linux machine, so I'm kind of trusting the documentation here.