### PR TITLE
Linux polling fallback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,6 +81,9 @@ module.exports = {
     logOption('workerLog', options, normalized)
     logOption('pollingLog', options, normalized)
 
+    if (options.pollingThrottle) normalized.pollingThrottle = options.pollingThrottle
+    if (options.pollingInterval) normalized.pollingInterval = options.pollingInterval
+
     return new Promise((resolve, reject) => {
       watcher.configure(normalized, err => (err ? reject(err) : resolve(err)))
     })

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -76,11 +76,16 @@ string FileSystemPayload::describe() const
   return builder.str();
 }
 
-CommandPayload::CommandPayload(CommandAction action, CommandID id, std::string &&root, uint_fast32_t arg) :
+CommandPayload::CommandPayload(CommandAction action,
+  CommandID id,
+  std::string &&root,
+  uint_fast32_t arg,
+  size_t split_count) :
   id{id},
   action{action},
   root{move(root)},
-  arg{arg}
+  arg{arg},
+  split_count{split_count}
 {
   //
 }
@@ -89,7 +94,8 @@ CommandPayload::CommandPayload(CommandPayload &&original) noexcept :
   id{original.id},
   action{original.action},
   root{move(original.root)},
-  arg{original.arg}
+  arg{original.arg},
+  split_count{original.split_count}
 {
   //
 }
@@ -108,6 +114,10 @@ string CommandPayload::describe() const
     case COMMAND_POLLING_THROTTLE: builder << "polling throttle " << arg; break;
     case COMMAND_DRAIN: builder << "drain"; break;
     default: builder << "!!action=" << action; break;
+  }
+
+  if (split_count > 1) {
+    builder << " split x" << split_count;
   }
 
   builder << "]";

--- a/src/message.h
+++ b/src/message.h
@@ -92,7 +92,8 @@ public:
   CommandPayload(CommandAction action,
     CommandID id = NULL_COMMAND_ID,
     std::string &&root = "",
-    uint_fast32_t arg = NULL_CHANNEL_ID);
+    uint_fast32_t arg = NULL_CHANNEL_ID,
+    size_t split_count = 1);
   CommandPayload(CommandPayload &&original) noexcept;
   ~CommandPayload() = default;
 
@@ -105,6 +106,7 @@ public:
   const std::string &get_root() const { return root; }
   const uint_fast32_t &get_arg() const { return arg; }
   const ChannelID &get_channel_id() const { return arg; }
+  const size_t &get_split_count() const { return split_count; }
 
   std::string describe() const;
 
@@ -113,6 +115,7 @@ private:
   const CommandAction action;
   std::string root;
   const uint_fast32_t arg;
+  const size_t split_count;
 };
 
 class AckPayload

--- a/src/message_buffer.h
+++ b/src/message_buffer.h
@@ -11,12 +11,8 @@ class MessageBuffer
 {
 public:
   MessageBuffer() = default;
-  MessageBuffer(const MessageBuffer &) = delete;
-  MessageBuffer(MessageBuffer &&) = delete;
-  ~MessageBuffer() = default;
 
-  MessageBuffer &operator=(const MessageBuffer &) = delete;
-  MessageBuffer &operator=(MessageBuffer &&) = delete;
+  ~MessageBuffer() = default;
 
   using iter = std::vector<Message>::iterator;
 
@@ -39,6 +35,11 @@ public:
   size_t size() { return messages.size(); }
 
   bool empty() { return messages.empty(); }
+
+  MessageBuffer(const MessageBuffer &) = delete;
+  MessageBuffer(MessageBuffer &&) = delete;
+  MessageBuffer &operator=(const MessageBuffer &) = delete;
+  MessageBuffer &operator=(MessageBuffer &&) = delete;
 
 private:
   std::vector<Message> messages;

--- a/src/message_buffer.h
+++ b/src/message_buffer.h
@@ -28,6 +28,8 @@ public:
 
   void reserve(size_t capacity) { messages.reserve(capacity); }
 
+  void add(Message &&message) { messages.emplace_back(std::move(message)); }
+
   MessageBuffer::iter begin() { return messages.begin(); }
 
   MessageBuffer::iter end() { return messages.end(); }

--- a/src/polling/polled_root.cpp
+++ b/src/polling/polled_root.cpp
@@ -9,11 +9,11 @@
 using std::move;
 using std::string;
 
-PolledRoot::PolledRoot(string &&root_path, CommandID command_id, ChannelID channel_id) :
+PolledRoot::PolledRoot(string &&root_path, ChannelID channel_id) :
   root(new DirectoryRecord(move(root_path))),
-  command_id{command_id},
   channel_id{channel_id},
-  iterator(root)
+  iterator(root),
+  all_populated{false}
 {
   //
 }
@@ -25,9 +25,8 @@ size_t PolledRoot::advance(MessageBuffer &buffer, size_t throttle_allocation)
 
   size_t progress = bound_iterator.advance(throttle_allocation);
 
-  if (command_id != NULL_COMMAND_ID && root->all_populated()) {
-    channel_buffer.ack(command_id, true, "");
-    command_id = NULL_COMMAND_ID;
+  if (!all_populated && root->all_populated()) {
+    all_populated = true;
   }
 
   return progress;

--- a/src/polling/polled_root.h
+++ b/src/polling/polled_root.h
@@ -18,13 +18,8 @@ public:
   //
   // The newly constructed root does *not* contain any initial scan information, to avoid CPU usage spikes when
   // watching large directory trees. The subtree's records will be populated on the first scan.
-  PolledRoot(std::string &&root_path, CommandID command_id, ChannelID channel_id);
+  PolledRoot(std::string &&root_path, ChannelID channel_id);
   ~PolledRoot() = default;
-
-  PolledRoot(const PolledRoot &) = delete;
-  PolledRoot(PolledRoot &&) = delete;
-  PolledRoot &operator=(const PolledRoot &) = delete;
-  PolledRoot &operator=(PolledRoot &&) = delete;
 
   // Perform at most `throttle_allocation` operations, accumulating any changes into a provided `buffer` for batch
   // delivery. Return the number of operations actually performed.
@@ -34,19 +29,26 @@ public:
   // left ready to begin again at the root directory next time.
   size_t advance(MessageBuffer &buffer, size_t throttle_allocation);
 
+  // Return `true` once the first complete scan has been completed by calls to `PolledRoot::advance()`.
+  bool is_all_populated() { return all_populated; }
+
+  PolledRoot(const PolledRoot &) = delete;
+  PolledRoot(PolledRoot &&) = delete;
+  PolledRoot &operator=(const PolledRoot &) = delete;
+  PolledRoot &operator=(PolledRoot &&) = delete;
+
 private:
   // Recursive data structure used to remember the last stat results from the entire filesystem subhierarchy.
   std::shared_ptr<DirectoryRecord> root;
-
-  // ID of the command that was used to add this root. Used to generate the ack message once the
-  // root has been populated, or NULL_COMMAND_ID if the ack has already been produced.
-  CommandID command_id;
 
   // Events produced by changes within this root should by targetted for this channel.
   ChannelID channel_id;
 
   // Persistent iteration state.
   PollingIterator iterator;
+
+  // Becomes `true` when the first full subtree scan has completed.
+  bool all_populated;
 
   // Diagnostics and logging are your friend.
   friend std::ostream &operator<<(std::ostream &out, const PolledRoot &root)

--- a/src/polling/polling_iterator.cpp
+++ b/src/polling/polling_iterator.cpp
@@ -4,12 +4,10 @@
 #include <string>
 
 #include "../helper/common.h"
-#include "../log.h"
 #include "../message_buffer.h"
 #include "directory_record.h"
 #include "polling_iterator.h"
 
-using std::endl;
 using std::shared_ptr;
 using std::string;
 
@@ -36,13 +34,10 @@ size_t BoundPollingIterator::advance(size_t throttle_allocation)
 
   while (count < total) {
     if (iterator.phase == PollingIterator::SCAN) {
-      LOGGER << *this << " performing SCAN." << endl;
       advance_scan();
     } else if (iterator.phase == PollingIterator::ENTRIES) {
-      LOGGER << *this << " performing ENTRIES." << endl;
       advance_entry();
     } else if (iterator.phase == PollingIterator::RESET) {
-      LOGGER << *this << " detected a RESET." << endl;
       break;
     }
     count++;
@@ -52,8 +47,6 @@ size_t BoundPollingIterator::advance(size_t throttle_allocation)
     iterator.current = iterator.root;
     iterator.current_path = iterator.current->path();
     iterator.phase = PollingIterator::SCAN;
-
-    LOGGER << *this << " has been reset back to its root." << endl;
   }
 
   return count;

--- a/src/polling/polling_thread.cpp
+++ b/src/polling/polling_thread.cpp
@@ -49,13 +49,11 @@ Result<> PollingThread::body()
       return ok_result();
     }
 
-    LOGGER << "Polling root directories." << endl;
     cycle();
 
     if (is_healthy()) {
       LOGGER << "Sleeping for " << poll_interval.count() << "ms." << endl;
       std::this_thread::sleep_for(poll_interval);
-      LOGGER << "Waking up." << endl;
     }
   }
 }

--- a/src/polling/polling_thread.cpp
+++ b/src/polling/polling_thread.cpp
@@ -75,7 +75,9 @@ Result<> PollingThread::cycle()
 
     size_t progress = root.advance(buffer, allotment);
     remaining -= progress;
-    LOGGER << root << " consumed " << plural(progress, "throttle slot") << "." << endl;
+    if (progress != allotment) {
+      LOGGER << root << " only consumed " << plural(progress, "throttle slot") << "." << endl;
+    }
 
     roots_left--;
   }

--- a/src/polling/polling_thread.cpp
+++ b/src/polling/polling_thread.cpp
@@ -1,11 +1,11 @@
 #include <chrono>
 #include <cstdint>
 #include <map>
-#include <vector>
 #include <string>
 #include <thread>
 #include <utility>
 #include <uv.h>
+#include <vector>
 
 #include "../log.h"
 #include "../message_buffer.h"
@@ -18,8 +18,8 @@
 using std::endl;
 using std::move;
 using std::string;
-using std::vector;
 using std::to_string;
+using std::vector;
 
 PollingThread::PollingThread(uv_async_t *main_callback) :
   Thread("polling thread", main_callback),

--- a/src/polling/polling_thread.cpp
+++ b/src/polling/polling_thread.cpp
@@ -168,12 +168,14 @@ Result<Thread::CommandOutcome> PollingThread::handle_add_command(const CommandPa
     return ok_result(NOTHING);
   }
 
-  pending_splits.emplace(std::piecewise_construct,
-    std::forward_as_tuple(command->get_channel_id()),
-    std::forward_as_tuple(command->get_id(), command->get_split_count()));
+  if (command->get_id() != NULL_COMMAND_ID) {
+    pending_splits.emplace(std::piecewise_construct,
+      std::forward_as_tuple(command->get_channel_id()),
+      std::forward_as_tuple(command->get_id(), command->get_split_count()));
 
-  if (command->get_split_count() == 0u) {
-    return ok_result(ACK);
+    if (command->get_split_count() == 0u) {
+      return ok_result(ACK);
+    }
   }
 
   return ok_result(NOTHING);

--- a/src/polling/polling_thread.cpp
+++ b/src/polling/polling_thread.cpp
@@ -184,10 +184,9 @@ Result<Thread::CommandOutcome> PollingThread::handle_add_command(const CommandPa
 Result<Thread::CommandOutcome> PollingThread::handle_remove_command(const CommandPayload *command)
 {
   const ChannelID &channel_id = command->get_channel_id();
-  LOGGER << "Removing poll root at channel " << channel_id << "." << endl;
+  LOGGER << "Removing poll roots at channel " << channel_id << "." << endl;
 
-  auto it = roots.find(command->get_channel_id());
-  if (it != roots.end()) roots.erase(it);
+  roots.erase(command->get_channel_id());
 
   // Ensure that we ack the ADD command even if the REMOVE command arrives before all of its splits populate.
   auto pending = pending_splits.find(channel_id);

--- a/src/polling/polling_thread.cpp
+++ b/src/polling/polling_thread.cpp
@@ -15,7 +15,9 @@
 #include "polling_thread.h"
 
 using std::endl;
+using std::move;
 using std::string;
+using std::to_string;
 
 PollingThread::PollingThread(uv_async_t *main_callback) :
   Thread("polling thread", main_callback),
@@ -63,13 +65,12 @@ Result<> PollingThread::cycle()
   MessageBuffer buffer;
   size_t remaining = poll_throttle;
 
-  auto it = roots.begin();
   size_t roots_left = roots.size();
   LOGGER << "Polling " << plural(roots_left, "root") << " with " << plural(poll_throttle, "throttle slot") << "."
          << endl;
 
-  while (it != roots.end()) {
-    PolledRoot &root = it->second;
+  for (auto &it : roots) {
+    PolledRoot &root = it.second;
     size_t allotment = remaining / roots_left;
 
     LOGGER << "Polling " << root << " with an allotment of " << plural(allotment, "throttle slot") << "." << endl;
@@ -79,7 +80,23 @@ Result<> PollingThread::cycle()
     LOGGER << root << " consumed " << plural(progress, "throttle slot") << "." << endl;
 
     roots_left--;
-    ++it;
+  }
+
+  // Ack any commands whose roots are now fully populated.
+  for (auto &split : pending_splits) {
+    const ChannelID &channel_id = split.first;
+    const PendingSplit &pending_split = split.second;
+
+    size_t populated_roots = 0;
+    auto channel_roots = roots.equal_range(channel_id);
+    for (auto root = channel_roots.first; root != channel_roots.second; ++root) {
+      if (root->second.is_all_populated()) populated_roots++;
+    }
+
+    if (populated_roots >= pending_split.second) {
+      buffer.ack(pending_split.first, channel_id, true, "");
+      pending_splits.erase(channel_id);
+    }
   }
 
   return emit_all(buffer.begin(), buffer.end());
@@ -107,22 +124,79 @@ Result<Thread::OfflineCommandOutcome> PollingThread::handle_offline_command(cons
 
 Result<Thread::CommandOutcome> PollingThread::handle_add_command(const CommandPayload *command)
 {
-  LOGGER << "Adding poll root at path " << command->get_root() << " to channel " << command->get_channel_id() << "."
-         << endl;
+  LOGGER << "Adding poll root at path " << command->get_root() << " to channel " << command->get_channel_id()
+         << " with " << plural(command->get_split_count(), "split") << "." << endl;
 
   roots.emplace(std::piecewise_construct,
     std::forward_as_tuple(command->get_channel_id()),
-    std::forward_as_tuple(string(command->get_root()), command->get_id(), command->get_channel_id()));
+    std::forward_as_tuple(string(command->get_root()), command->get_channel_id()));
+
+  auto existing = pending_splits.find(command->get_channel_id());
+  if (existing != pending_splits.end()) {
+    bool inconsistent = false;
+    string msg("Inconsistent split ADD command received by polling thread: ");
+
+    const CommandID &existing_command_id = existing->second.first;
+    const size_t &split_count = existing->second.second;
+
+    if (existing_command_id != command->get_id()) {
+      inconsistent = true;
+
+      msg += " command ID (";
+      msg += to_string(existing_command_id);
+      msg += " => ";
+      msg += to_string(command->get_id());
+      msg += ")";
+    }
+
+    if (split_count != command->get_split_count()) {
+      if (inconsistent) {
+        msg += " and";
+      }
+
+      msg += " split count (";
+      msg += to_string(split_count);
+      msg += " => ";
+      msg += to_string(command->get_split_count());
+      msg += ")";
+    }
+
+    if (inconsistent) {
+      return Result<CommandOutcome>::make_error(move(msg));
+    }
+
+    return ok_result(NOTHING);
+  }
+
+  pending_splits.emplace(std::piecewise_construct,
+    std::forward_as_tuple(command->get_channel_id()),
+    std::forward_as_tuple(command->get_id(), command->get_split_count()));
+
+  if (command->get_split_count() == 0u) {
+    return ok_result(ACK);
+  }
 
   return ok_result(NOTHING);
 }
 
 Result<Thread::CommandOutcome> PollingThread::handle_remove_command(const CommandPayload *command)
 {
-  LOGGER << "Removing poll root at channel " << command->get_channel_id() << "." << endl;
+  const ChannelID &channel_id = command->get_channel_id();
+  LOGGER << "Removing poll root at channel " << channel_id << "." << endl;
 
   auto it = roots.find(command->get_channel_id());
   if (it != roots.end()) roots.erase(it);
+
+  // Ensure that we ack the ADD command even if the REMOVE command arrives before all of its splits populate.
+  auto pending = pending_splits.find(channel_id);
+  if (pending != pending_splits.end()) {
+    const PendingSplit &split = pending->second;
+    const CommandID &add_command_id = split.first;
+
+    Result<> r0 = emit(Message(AckPayload(add_command_id, channel_id, false, "Command cancelled")));
+    pending_splits.erase(pending);
+    if (r0.is_error()) return r0.propagate<CommandOutcome>();
+  }
 
   if (roots.empty()) {
     LOGGER << "Final root removed." << endl;

--- a/src/polling/polling_thread.h
+++ b/src/polling/polling_thread.h
@@ -4,6 +4,8 @@
 #include <chrono>
 #include <cstdint>
 #include <map>
+#include <set>
+#include <utility>
 #include <uv.h>
 
 #include "../result.h"
@@ -56,7 +58,10 @@ private:
   std::chrono::milliseconds poll_interval;
   uint_fast32_t poll_throttle;
 
-  std::map<ChannelID, PolledRoot> roots;
+  std::multimap<ChannelID, PolledRoot> roots;
+
+  using PendingSplit = std::pair<CommandID, size_t>;
+  std::map<ChannelID, PendingSplit> pending_splits;
 };
 
 #endif

--- a/src/worker/linux/side_effect.cpp
+++ b/src/worker/linux/side_effect.cpp
@@ -9,17 +9,23 @@
 
 using std::move;
 using std::string;
+using std::vector;
 
 void SideEffect::track_subdirectory(string subdir, ChannelID channel_id)
 {
   subdirectories.emplace_back(move(subdir), channel_id);
 }
 
-Result<> SideEffect::enact_in(WatchRegistry *registry)
+Result<> SideEffect::enact_in(WatchRegistry *registry, vector<PollingRoot> &poll)
 {
   Result<> r = ok_result();
   for (Subdirectory &subdir : subdirectories) {
-    r &= registry->add(subdir.channel_id, subdir.path, true);
+    vector<string> poll_roots;
+    r &= registry->add(subdir.channel_id, subdir.path, true, poll_roots);
+
+    for (string &poll_root : poll_roots) {
+      poll.emplace_back(subdir.channel_id, move(poll_root));
+    }
   }
   return r;
 }

--- a/src/worker/linux/side_effect.h
+++ b/src/worker/linux/side_effect.h
@@ -19,11 +19,13 @@ public:
   SideEffect() = default;
   ~SideEffect() = default;
 
+  using PollingRoot = std::pair<ChannelID, std::string>;
+
   // Recursively watch a newly created subdirectory.
   void track_subdirectory(std::string subdir, ChannelID channel_id);
 
   // Perform all enqueued actions.
-  Result<> enact_in(WatchRegistry *registry);
+  Result<> enact_in(WatchRegistry *registry, std::vector<PollingRoot> &poll);
 
   SideEffect(const SideEffect &other) = delete;
   SideEffect(SideEffect &&other) = delete;

--- a/src/worker/linux/watch_registry.h
+++ b/src/worker/linux/watch_registry.h
@@ -24,11 +24,12 @@ public:
   // Stop inotify and release all kernel resources associated with it.
   ~WatchRegistry() override;
 
-  // Begin watching a root path. If `recursive` is `true`, recursively watch all
-  // subdirectories as well.
+  // Begin watching a root path. If `recursive` is `true`, recursively watch all subdirectories as well. If inotify
+  // watch descriptors are exhausted before the entire directory tree can be watched, the unsuccessfully watched roots
+  // will be accumulated into the `poll` vector.
   //
   // `root` must name a directory if `recursive` is `true`.
-  Result<> add(ChannelID channel_id, const std::string &root, bool recursive);
+  Result<> add(ChannelID channel_id, const std::string &root, bool recursive, std::vector<std::string> &poll);
 
   // Uninstall inotify watchers used to deliver events on a specified channel.
   Result<> remove(ChannelID channel_id);


### PR DESCRIPTION
Automatically fall back to polling when inotify runs out of watch descriptors.

This is trickier than the Windows and MacOS implementations because a single ADD command can _partially_ succeed in inotify-land. This means that an ADD sent to the worker thread could need to send multiple ADDs to the polling thread, and the AckMessage should only be produced once all of the polling ADDs have done their initial scan.

Fixes #5.