### PR TITLE
Windows fixes

### DIFF
--- a/src/hub.h
+++ b/src/hub.h
@@ -52,7 +52,7 @@ public:
 
   Result<> disable_worker_log(std::unique_ptr<Nan::Callback> callback)
   {
-    return send_command(worker_thread, CommandPayloadBuilder::log_to_stderr(), std::move(callback));
+    return send_command(worker_thread, CommandPayloadBuilder::log_disable(), std::move(callback));
   }
 
   Result<> use_polling_log_file(std::string &&polling_log_file, std::unique_ptr<Nan::Callback> callback)

--- a/src/polling/directory_record.cpp
+++ b/src/polling/directory_record.cpp
@@ -125,9 +125,9 @@ void DirectoryRecord::scan(BoundPollingIterator *it)
         entry_deleted(it, previous_entry_path, previous_entry_kind);
         auto former = previous;
         ++previous;
-        entries.erase(former);
 
         subdirectories.erase(previous_entry_name);
+        entries.erase(former);
       } else {
         ++previous;
       }


### PR DESCRIPTION
Fix a few issues I noticed while I'm on the Windows box:

* A crash in the polling thread tests when built in debug mode
* Disable means disable, not "actually log to stderr" kthx