### PR TITLE
Watch a single file

### DIFF
--- a/lib/path-watcher.js
+++ b/lib/path-watcher.js
@@ -65,6 +65,18 @@ class PathWatcher {
     this.native = null
     this.changeCallbacks = new Map()
 
+    this.attachedPromise = new Promise((resolve, reject) => {
+      this.resolveAttachedPromise = resolve
+      this.rejectAttachedPromise = reject
+    })
+    this.attachedPromise.catch(() => {})
+
+    this.startPromise = new Promise((resolve, reject) => {
+      this.resolveStartPromise = resolve
+      this.rejectStartPromise = reject
+    })
+    this.startPromise.catch(() => {})
+
     this.normalizedPathPromise = Promise.all([
       fs.realpath(watchedPath),
       fs.stat(watchedPath)
@@ -79,23 +91,6 @@ class PathWatcher {
 
       return this.normalizedPath
     })
-    fs.realpath(watchedPath).then(real => {
-      this.normalizedPath = real
-      return real
-    })
-
-    this.attachedPromise = new Promise((resolve, reject) => {
-      this.resolveAttachedPromise = resolve
-      this.rejectAttachedPromise = reject
-    })
-    this.attachedPromise.catch(() => {})
-
-    this.startPromise = new Promise((resolve, reject) => {
-      this.resolveStartPromise = resolve
-      this.rejectStartPromise = reject
-    })
-    this.startPromise.catch(() => {})
-
     this.normalizedPathPromise.catch(err => this.rejectStartPromise(err))
     this.normalizedPathPromise.catch(err => this.rejectAttachedPromise(err))
 

--- a/lib/path-watcher.js
+++ b/lib/path-watcher.js
@@ -59,13 +59,27 @@ class PathWatcher {
   constructor (nativeWatcherRegistry, watchedPath, options) {
     this.nativeWatcherRegistry = nativeWatcherRegistry
     this.watchedPath = watchedPath
-    this.options = Object.assign({recursive: true}, options)
+    this.options = Object.assign({recursive: true, include: () => true}, options)
 
     this.normalizedPath = null
     this.native = null
     this.changeCallbacks = new Map()
 
-    this.normalizedPathPromise = fs.realpath(watchedPath).then(real => {
+    this.normalizedPathPromise = Promise.all([
+      fs.realpath(watchedPath),
+      fs.stat(watchedPath)
+    ]).then(([real, stat]) => {
+      if (stat.isDirectory()) {
+        this.normalizedPath = real
+      } else {
+        this.normalizedPath = path.dirname(real)
+        this.options.recursive = false
+        this.options.include = p => p === real
+      }
+
+      return this.normalizedPath
+    })
+    fs.realpath(watchedPath).then(real => {
       this.normalizedPath = real
       return real
     })
@@ -214,11 +228,37 @@ class PathWatcher {
   // events may include events for paths above this watcher's root path, so filter them to only include the relevant
   // ones, then re-broadcast them to our subscribers.
   onNativeEvents (events, callback) {
-    const filtered = events.filter(
-      this.options.recursive
-        ? event => event.path.startsWith(this.normalizedPath)
-        : event => path.dirname(event.path) === this.normalizedPath || event.path === this.normalizedPath
-    )
+    const isWatchedPath = eventPath => {
+      if (!eventPath.startsWith(this.normalizedPath)) return false
+      if (this.options.recursive) {
+        if (path.dirname(eventPath) !== this.normalizedPath && eventPath !== this.normalizedPath) return false
+      }
+      if (!this.options.include(eventPath)) return false
+
+      return true
+    }
+
+    const filtered = []
+    for (let i = 0; i < events.length; i++) {
+      const event = events[i]
+
+      if (event.action === 'renamed') {
+        const srcWatched = isWatchedPath(event.oldPath)
+        const destWatched = isWatchedPath(event.path)
+
+        if (srcWatched && destWatched) {
+          filtered.push(event)
+        } else if (srcWatched && !destWatched) {
+          filtered.push({action: 'deleted', kind: event.kind, path: event.oldPath})
+        } else if (!srcWatched && destWatched) {
+          filtered.push({action: 'created', kind: event.kind, path: event.path})
+        }
+      } else {
+        if (isWatchedPath(event.path)) {
+          filtered.push(event)
+        }
+      }
+    }
 
     if (filtered.length > 0) {
       callback(filtered)

--- a/lib/path-watcher.js
+++ b/lib/path-watcher.js
@@ -96,10 +96,6 @@ class PathWatcher {
     })
     this.startPromise.catch(() => {})
 
-    this.normalizedPathPromise = fs.realpath(watchedPath).then(real => {
-      this.normalizedPath = real
-      return real
-    })
     this.normalizedPathPromise.catch(err => this.rejectStartPromise(err))
     this.normalizedPathPromise.catch(err => this.rejectAttachedPromise(err))
 

--- a/lib/path-watcher.js
+++ b/lib/path-watcher.js
@@ -230,7 +230,7 @@ class PathWatcher {
   onNativeEvents (events, callback) {
     const isWatchedPath = eventPath => {
       if (!eventPath.startsWith(this.normalizedPath)) return false
-      if (this.options.recursive) {
+      if (!this.options.recursive) {
         if (path.dirname(eventPath) !== this.normalizedPath && eventPath !== this.normalizedPath) return false
       }
       if (!this.options.include(eventPath)) return false

--- a/src/worker/macos/batch_handler.cpp
+++ b/src/worker/macos/batch_handler.cpp
@@ -129,6 +129,7 @@ bool Event::emit_if_unambiguous()
       former_kind = former->get_entry_kind();
     }
 
+    cache().evict(event_path);
     message_buffer().deleted(move(event_path), former_kind);
     return true;
   }
@@ -144,8 +145,7 @@ bool Event::emit_if_unambiguous()
 bool Event::emit_if_rename()
 {
   if (flag_renamed()) {
-    rename_buffer().observe_event(*this);
-    return true;
+    return rename_buffer().observe_event(*this, cache());
   }
 
   return false;
@@ -169,6 +169,7 @@ bool Event::emit_if_absent()
   // It isn't there now, so it must have been deleted.
   if (flag_deleted()) {
     message_buffer().deleted(string(current->get_path()), current->get_entry_kind());
+    cache().evict(current->get_path());
   }
   return true;
 }

--- a/src/worker/macos/recent_file_cache.cpp
+++ b/src/worker/macos/recent_file_cache.cpp
@@ -127,7 +127,7 @@ bool PresentEntry::could_be_rename_of(const StatResult &other) const
   if (other.is_absent()) return false;
 
   const auto &casted = static_cast<const PresentEntry &>(other);  // NOLINT
-  return inode == casted.get_inode();
+  return inode == casted.get_inode() && !kinds_are_different(get_entry_kind(), casted.get_entry_kind());
 }
 
 ino_t PresentEntry::get_inode() const

--- a/src/worker/macos/recent_file_cache.cpp
+++ b/src/worker/macos/recent_file_cache.cpp
@@ -171,10 +171,7 @@ bool AbsentEntry::has_changed_from(const StatResult &other) const
 
 bool AbsentEntry::could_be_rename_of(const StatResult &other) const
 {
-  if (!StatResult::could_be_rename_of(other)) return false;
-  if (other.is_present()) return false;
-
-  return true;
+  return false;
 }
 
 string AbsentEntry::to_string(bool verbose) const

--- a/src/worker/macos/recent_file_cache.cpp
+++ b/src/worker/macos/recent_file_cache.cpp
@@ -299,7 +299,7 @@ void RecentFileCache::prepopulate(const string &root, size_t max)
     next_roots.pop();
 
     DIR *dir = opendir(current_root.c_str());
-    if (dir != nullptr) {
+    if (dir == nullptr) {
       errno_t opendir_errno = errno;
       LOGGER << "Unable to open directory " << root << ": " << strerror(opendir_errno) << "." << endl;
       LOGGER << "Incompletely pre-populated cache with " << entries << " entries." << endl;

--- a/src/worker/macos/recent_file_cache.cpp
+++ b/src/worker/macos/recent_file_cache.cpp
@@ -169,7 +169,7 @@ bool AbsentEntry::has_changed_from(const StatResult &other) const
   return false;
 }
 
-bool AbsentEntry::could_be_rename_of(const StatResult &other) const
+bool AbsentEntry::could_be_rename_of(const StatResult & /*other*/) const
 {
   return false;
 }
@@ -234,7 +234,7 @@ void RecentFileCache::evict(const string &path)
   }
 }
 
-void RecentFileCache::evict(const shared_ptr<PresentEntry> entry)
+void RecentFileCache::evict(const shared_ptr<PresentEntry> &entry)
 {
   auto maybe = by_path.find(entry->get_path());
   if (maybe != by_path.end() && maybe->second == entry) {

--- a/src/worker/macos/recent_file_cache.h
+++ b/src/worker/macos/recent_file_cache.h
@@ -109,6 +109,10 @@ public:
 
   std::shared_ptr<StatResult> former_at_path(const std::string &path, bool file_hint, bool directory_hint);
 
+  void evict(const std::string &path);
+
+  void evict(const std::shared_ptr<PresentEntry> entry);
+
   void apply();
 
   void prune();

--- a/src/worker/macos/recent_file_cache.h
+++ b/src/worker/macos/recent_file_cache.h
@@ -111,7 +111,7 @@ public:
 
   void evict(const std::string &path);
 
-  void evict(const std::shared_ptr<PresentEntry> entry);
+  void evict(const std::shared_ptr<PresentEntry> &entry);
 
   void apply();
 

--- a/src/worker/macos/rename_buffer.cpp
+++ b/src/worker/macos/rename_buffer.cpp
@@ -114,18 +114,18 @@ bool RenameBuffer::observe_present_entry(ChannelMessageBuffer &message_buffer,
 
     observed_by_inode.erase(maybe_entry);
     return handled;
-  } else {
-    string existing_desc = existing.current ? " (current) " : " (former) ";
-    string incoming_desc = current ? " (current) " : " (former) ";
-
-    logline << "conflicting pair " << *present << incoming_desc << " =/= " << *(existing.entry) << existing_desc
-            << "have conflicting entry kinds." << endl;
-    return false;
   }
+
+  string existing_desc = existing.current ? " (current) " : " (former) ";
+  string incoming_desc = current ? " (current) " : " (former) ";
+
+  logline << "conflicting pair " << *present << incoming_desc << " =/= " << *(existing.entry) << existing_desc
+          << "have conflicting entry kinds." << endl;
+  return false;
 }
 
 bool RenameBuffer::observe_absent(ChannelMessageBuffer &message_buffer,
-  RecentFileCache &cache,
+  RecentFileCache & /*cache*/,
   const std::shared_ptr<AbsentEntry> &absent)
 {
   LOGGER << "Unable to correlate rename from " << absent->get_path() << " without an inode." << endl;

--- a/src/worker/macos/rename_buffer.h
+++ b/src/worker/macos/rename_buffer.h
@@ -48,8 +48,9 @@ public:
   using Key = ino_t;
 
   // Observe a rename event for a filesystem event. Deduce the matching side of the rename, if possible,
-  // based on the previous and currently observed state of the entry at that path.
-  void observe_event(Event &event);
+  // based on the previous and currently observed state of the entry at that path. Return "true" if the event
+  // is consumed, or "false" if it should be treated as something other than a rename.
+  bool observe_event(Event &event, RecentFileCache &cache);
 
   // Enqueue creation and removal events for any buffer entries that have remained unpaired through two consecutive
   // event batches.
@@ -68,11 +69,14 @@ public:
   RenameBuffer &operator=(RenameBuffer &&) = delete;
 
 private:
-  void observe_present_entry(ChannelMessageBuffer &message_buffer,
+  bool observe_present_entry(ChannelMessageBuffer &message_buffer,
+    RecentFileCache &cache,
     const std::shared_ptr<PresentEntry> &present,
     bool current);
 
-  void observe_absent(ChannelMessageBuffer &message_buffer, const std::shared_ptr<AbsentEntry> &absent);
+  bool observe_absent(ChannelMessageBuffer &message_buffer,
+    RecentFileCache &cache,
+    const std::shared_ptr<AbsentEntry> &absent);
 
   std::unordered_map<Key, RenameBufferEntry> observed_by_inode;
 };

--- a/test/matcher.js
+++ b/test/matcher.js
@@ -16,6 +16,10 @@ class EventMatcher {
     return this.fixture.watch(...args, (err, events) => {
       this.errors.push(err)
       this.events.push(...events)
+
+      if (process.env.VERBOSE) {
+        console.log(events)
+      }
     })
   }
 


### PR DESCRIPTION
When called with the name of a single file, create a non-recursive `PathWatcher` on its parent directory that only reports events that pertain to that file's path.

- [x] Filter `PathWatcher` events in JavaScript.
- [x] Identify file paths when normalizing a watcher path. Configure the watcher to filter out all other events.
- [x] Address regressions related to macOS heuristics.
  - [x] Evict stat results from the `RecentFileCache` once an event is emitted that determines where its entry went (a deletion or a rename).