### PR TITLE
Lazily require native bindings

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -65,7 +65,7 @@ function configure (options) {
 
 function lazy (key) {
   return function (...args) {
-    getWatcher()[key](...args)
+    return getWatcher()[key](...args)
   }
 }
 

--- a/lib/binding.js
+++ b/lib/binding.js
@@ -1,8 +1,14 @@
 let watcher = null
-try {
-  watcher = require('../build/Release/watcher.node')
-} catch (err) {
-  watcher = require('../build/Debug/watcher.node')
+
+function getWatcher () {
+  if (!watcher) {
+    try {
+      watcher = require('../build/Release/watcher.node')
+    } catch (err) {
+      watcher = require('../build/Debug/watcher.node')
+    }
+  }
+  return watcher
 }
 
 // Private: Logging mode constants
@@ -53,15 +59,21 @@ function configure (options) {
   if (options.pollingInterval) normalized.pollingInterval = options.pollingInterval
 
   return new Promise((resolve, reject) => {
-    watcher.configure(normalized, err => (err ? reject(err) : resolve(err)))
+    getWatcher().configure(normalized, err => (err ? reject(err) : resolve(err)))
   })
 }
 
+function lazy (key) {
+  return function (...args) {
+    getWatcher()[key](...args)
+  }
+}
+
 module.exports = {
-  watch: watcher.watch,
-  unwatch: watcher.unwatch,
+  watch: lazy('watch'),
+  unwatch: lazy('unwatch'),
   configure,
-  status: watcher.status,
+  status: lazy('status'),
 
   DISABLE,
   STDERR,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@atom/watcher",
-  "version": "0.0.5",
+  "version": "0.0.6-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atom/watcher",
-  "version": "0.0.5",
+  "version": "0.0.6-0",
   "description": "Atom filesystem watcher",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Directly exporting symbols required from the native bindings makes electron-link unhappy. Make _those_ functions defer use of the native bindings to make the whole thing snapshottable.