### PR TITLE
Remove SyncErrable

### DIFF
--- a/src/errable.cpp
+++ b/src/errable.cpp
@@ -1,30 +1,22 @@
-#include <iostream>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <uv.h>
 
 #include "errable.h"
-#include "lock.h"
+#include "result.h"
 
 using std::move;
-using std::ostream;
 using std::string;
 
-Errable::Errable(string &&source) : healthy{true}, source{move(source)}, message{"ok"}
+Result<> Errable::health_err_result() const
 {
-  //
+  if (message.empty()) return ok_result();
+  return error_result(string(message));
 }
 
-bool Errable::is_healthy()
+void Errable::report_errable(const Errable &component)
 {
-  return healthy;
-}
-
-void Errable::report_error(string &&message)
-{
-  healthy = false;
-  this->message = move(message);
+  report_if_error(component.health_err_result());
 }
 
 void Errable::report_uv_error(int err_code)
@@ -32,50 +24,8 @@ void Errable::report_uv_error(int err_code)
   report_error(uv_strerror(err_code));
 }
 
-string Errable::get_error()
+void Errable::report_error(string &&message)
 {
-  return message;
-}
-
-SyncErrable::SyncErrable(string &&source) : Errable(move(source))
-{
-  int err = uv_rwlock_init(&rwlock);
-
-  if (err != 0) {
-    Errable::report_error(uv_strerror(err));
-    lock_healthy = false;
-  } else {
-    lock_healthy = true;
-  }
-}
-
-SyncErrable::~SyncErrable()
-{
-  uv_rwlock_destroy(&rwlock);
-}
-
-bool SyncErrable::is_healthy()
-{
-  if (!lock_healthy) {
-    return false;
-  }
-
-  ReadLock lock(rwlock);
-  return Errable::is_healthy();
-}
-
-void SyncErrable::report_error(string &&message)
-{
-  if (!lock_healthy) return;
-
-  WriteLock lock(rwlock);
-  Errable::report_error(move(message));
-}
-
-string SyncErrable::get_error()
-{
-  if (!lock_healthy) return Errable::get_error();
-
-  ReadLock lock(rwlock);
-  return Errable::get_error();
+  assert(!frozen);
+  this->message = move(message);
 }

--- a/src/errable.h
+++ b/src/errable.h
@@ -54,7 +54,7 @@ protected:
   void freeze() { frozen = true; }
 
 private:
-  bool frozen;
+  bool frozen{false};
   std::string message;
 };
 

--- a/src/errable.h
+++ b/src/errable.h
@@ -8,77 +8,52 @@
 
 #include "result.h"
 
-// Superclass for resources that can potentially enter an errored state.
+// Superclass for resources that can potentially fail to be constructed properly.
 //
-// Resources begin "healthy". If an operation necessary for the continued use of the
-// resource is unsuccessful (a file can't be opened, a thread can't be started), one of
-// the report_error() methods should be called with a message describing the failure
-// state.
+// While a resource is being constructed, if a required resource cannot be initialized correctly, call one of the
+// report_error() functions to mark it as "unhealthy". Before exiting the constructor, call freeze() to prevent further
+// modifications.
 //
-// All methods on the subclass should verify that is_health() returns true before
-// attempting to take any actions, and return early otherwise, indicating failure.
-//
-// External consumers of the resource can use get_error() to log the cause of the failure.
+// External consumers of the resource can use health_err_result() to log the cause of the failure.
 class Errable
 {
 public:
-  explicit Errable(std::string &&source);
-  Errable(const Errable &) = delete;
-  Errable(Errable &&) = delete;
+  Errable() = default;
+
   virtual ~Errable() = default;
 
-  virtual bool is_healthy();
-  virtual void report_error(std::string &&message);
-
-  template <class V = void *>
-  void report_error(const Result<V> &result)
-  {
-    report_error(std::string(result.get_error()));
-  }
-
-  void report_uv_error(int err_code);
-
-  virtual std::string get_error();
+  std::string get_message() const { return message.empty() ? "ok" : message; }
 
   // Generate a Result from the current error status of this resource. If it has entered an error state,
-  // an errored Result will be created with its error message. Otherwise, an ok Result will be regurned.
-  template <class V = void *>
-  Result<V> health_err_result()
-  {
-    std::string m = get_error();
-    return Result<V>::make_error(std::move(m));
-  }
+  // an errored Result will be created with its error message. Otherwise, an ok Result will be returned.
+  Result<> health_err_result() const;
 
-  const std::string &get_source() const { return source; }
-
+  Errable(const Errable &) = delete;
+  Errable(Errable &&) = delete;
   Errable &operator=(const Errable &) = delete;
   Errable &operator=(Errable &&) = delete;
 
+protected:
+  void report_errable(const Errable &component);
+
+  void report_uv_error(int err_code);
+
+  void report_error(std::string &&message);
+
+  template <class V = void *>
+  void report_if_error(const Result<V> &result)
+  {
+    assert(!frozen);
+
+    if (result.is_ok()) return;
+    report_error(std::string(result.get_error()));
+  }
+
+  void freeze() { frozen = true; }
+
 private:
-  bool healthy;
-  std::string source;
+  bool frozen;
   std::string message;
-};
-
-// Thread-safe superclass for resources that can enter an errored state.
-class SyncErrable : public Errable
-{
-public:
-  explicit SyncErrable(std::string &&source);
-  SyncErrable(const SyncErrable &) = delete;
-  SyncErrable(SyncErrable &&) = delete;
-  ~SyncErrable() override;
-
-  bool is_healthy() override;
-  void report_error(std::string &&message) override;
-  std::string get_error() override;
-
-  SyncErrable &operator=(const SyncErrable &) = delete;
-  SyncErrable &operator=(SyncErrable &&) = delete;
-
-private:
-  bool lock_healthy;
-  uv_rwlock_t rwlock{};
 };
 
 #endif

--- a/src/errable.h
+++ b/src/errable.h
@@ -22,6 +22,8 @@ public:
 
   virtual ~Errable() = default;
 
+  bool is_healthy() const { return message.empty(); }
+
   std::string get_message() const { return message.empty() ? "ok" : message; }
 
   // Generate a Result from the current error status of this resource. If it has entered an error state,

--- a/src/hub.cpp
+++ b/src/hub.cpp
@@ -141,13 +141,7 @@ void Hub::handle_events_from(Thread &thread)
   Nan::HandleScope scope;
   bool repeat = true;
 
-  Result<unique_ptr<vector<Message>>> rr = thread.receive_all();
-  if (rr.is_error()) {
-    LOGGER << "Unable to receive messages from thread: " << rr << "." << endl;
-    return;
-  }
-
-  unique_ptr<vector<Message>> &accepted = rr.get_value();
+  unique_ptr<vector<Message>> accepted = thread.receive_all();
   if (!accepted) {
     // No events to process.
     return;

--- a/src/hub.cpp
+++ b/src/hub.cpp
@@ -52,10 +52,16 @@ Hub::Hub() :
 {
   int err;
 
-  err = uv_async_init(uv_default_loop(), &event_handler, handle_events_helper);
-  if (err != 0) return;
+  report_errable(worker_thread);
+  report_errable(polling_thread);
 
-  worker_thread.run();
+  err = uv_async_init(uv_default_loop(), &event_handler, handle_events_helper);
+  if (err != 0) {
+    report_uv_error(err);
+  }
+
+  report_if_error(worker_thread.run());
+  freeze();
 }
 
 Result<> Hub::watch(string &&root,

--- a/src/hub.h
+++ b/src/hub.h
@@ -8,13 +8,14 @@
 #include <utility>
 #include <uv.h>
 
+#include "errable.h"
 #include "log.h"
 #include "message.h"
 #include "polling/polling_thread.h"
 #include "result.h"
 #include "worker/worker_thread.h"
 
-class Hub
+class Hub : public Errable
 {
 public:
   static Hub &get() { return the_hub; }

--- a/src/hub.h
+++ b/src/hub.h
@@ -29,77 +29,109 @@ public:
 
   Result<> use_main_log_file(std::string &&main_log_file)
   {
+    Result<> h = health_err_result();
+    if (h.is_error()) return h;
+
     std::string r = Logger::to_file(main_log_file.c_str());
     return r.empty() ? ok_result() : error_result(std::move(r));
   }
 
   Result<> use_main_log_stderr()
   {
+    Result<> h = health_err_result();
+    if (h.is_error()) return h;
+
     std::string r = Logger::to_stderr();
     return r.empty() ? ok_result() : error_result(std::move(r));
   }
 
   Result<> use_main_log_stdout()
   {
+    Result<> h = health_err_result();
+    if (h.is_error()) return h;
+
     std::string r = Logger::to_stdout();
     return r.empty() ? ok_result() : error_result(std::move(r));
   }
 
   Result<> disable_main_log()
   {
+    Result<> h = health_err_result();
+    if (h.is_error()) return h;
+
     std::string r = Logger::disable();
     return r.empty() ? ok_result() : error_result(std::move(r));
   }
 
   Result<> use_worker_log_file(std::string &&worker_log_file, std::unique_ptr<Nan::Callback> callback)
   {
+    if (!check_async(callback)) return ok_result();
+
     return send_command(
       worker_thread, CommandPayloadBuilder::log_to_file(std::move(worker_log_file)), std::move(callback));
   }
 
   Result<> use_worker_log_stderr(std::unique_ptr<Nan::Callback> callback)
   {
+    if (!check_async(callback)) return ok_result();
+
     return send_command(worker_thread, CommandPayloadBuilder::log_to_stderr(), std::move(callback));
   }
 
   Result<> use_worker_log_stdout(std::unique_ptr<Nan::Callback> callback)
   {
+    if (!check_async(callback)) return ok_result();
+
     return send_command(worker_thread, CommandPayloadBuilder::log_to_stdout(), std::move(callback));
   }
 
   Result<> disable_worker_log(std::unique_ptr<Nan::Callback> callback)
   {
+    if (!check_async(callback)) return ok_result();
+
     return send_command(worker_thread, CommandPayloadBuilder::log_disable(), std::move(callback));
   }
 
   Result<> use_polling_log_file(std::string &&polling_log_file, std::unique_ptr<Nan::Callback> callback)
   {
+    if (!check_async(callback)) return ok_result();
+
     return send_command(
       polling_thread, CommandPayloadBuilder::log_to_file(std::move(polling_log_file)), std::move(callback));
   }
 
   Result<> use_polling_log_stderr(std::unique_ptr<Nan::Callback> callback)
   {
+    if (!check_async(callback)) return ok_result();
+
     return send_command(polling_thread, CommandPayloadBuilder::log_to_stderr(), std::move(callback));
   }
 
   Result<> use_polling_log_stdout(std::unique_ptr<Nan::Callback> callback)
   {
+    if (!check_async(callback)) return ok_result();
+
     return send_command(polling_thread, CommandPayloadBuilder::log_to_stdout(), std::move(callback));
   }
 
   Result<> disable_polling_log(std::unique_ptr<Nan::Callback> callback)
   {
+    if (!check_async(callback)) return ok_result();
+
     return send_command(polling_thread, CommandPayloadBuilder::log_disable(), std::move(callback));
   }
 
   Result<> set_polling_interval(uint_fast32_t interval, std::unique_ptr<Nan::Callback> callback)
   {
+    if (!check_async(callback)) return ok_result();
+
     return send_command(polling_thread, CommandPayloadBuilder::polling_interval(interval), std::move(callback));
   }
 
   Result<> set_polling_throttle(uint_fast32_t throttle, std::unique_ptr<Nan::Callback> callback)
   {
+    if (!check_async(callback)) return ok_result();
+
     return send_command(polling_thread, CommandPayloadBuilder::polling_throttle(throttle), std::move(callback));
   }
 
@@ -138,6 +170,8 @@ private:
   Hub();
 
   Result<> send_command(Thread &thread, CommandPayloadBuilder &&builder, std::unique_ptr<Nan::Callback> callback);
+
+  bool check_async(const std::unique_ptr<Nan::Callback> &callback);
 
   void handle_events_from(Thread &thread);
 

--- a/src/hub.h
+++ b/src/hub.h
@@ -22,7 +22,7 @@ public:
 
   Hub(const Hub &) = delete;
   Hub(Hub &&) = delete;
-  ~Hub() = default;
+  ~Hub() override = default;
 
   Hub &operator=(const Hub &) = delete;
   Hub &operator=(Hub &&) = delete;

--- a/src/polling/polling_thread.cpp
+++ b/src/polling/polling_thread.cpp
@@ -30,7 +30,7 @@ PollingThread::PollingThread(uv_async_t *main_callback) :
   poll_interval{DEFAULT_POLL_INTERVAL},
   poll_throttle{DEFAULT_POLL_THROTTLE}
 {
-  //
+  freeze();
 }
 
 Result<> PollingThread::body()
@@ -51,12 +51,8 @@ Result<> PollingThread::body()
       return r.propagate_as_void();
     }
 
-    if (is_healthy()) {
-      LOGGER << "Sleeping for " << poll_interval.count() << "ms." << endl;
-      std::this_thread::sleep_for(poll_interval);
-    } else {
-      return health_err_result<>();
-    }
+    LOGGER << "Sleeping for " << poll_interval.count() << "ms." << endl;
+    std::this_thread::sleep_for(poll_interval);
   }
 }
 
@@ -236,7 +232,7 @@ Result<Thread::CommandOutcome> PollingThread::handle_status_command(const Comman
   unique_ptr<Status> status{new Status()};
 
   status->polling_thread_state = state_name();
-  status->polling_thread_ok = get_error();
+  status->polling_thread_ok = get_message();
   status->polling_in_size = get_in_queue_size();
   status->polling_in_ok = get_in_queue_error();
   status->polling_out_size = get_out_queue_size();

--- a/src/queue.h
+++ b/src/queue.h
@@ -53,7 +53,7 @@ public:
   Queue &operator=(Queue &&) = delete;
 
 private:
-  uv_mutex_t mutex;
+  uv_mutex_t mutex{};
   std::unique_ptr<std::vector<Message>> active;
 };
 

--- a/src/queue.h
+++ b/src/queue.h
@@ -22,40 +22,38 @@
 class Queue : public Errable
 {
 public:
-  explicit Queue(std::string &&name = "queue");
-  Queue(const Queue &) = delete;
-  Queue(Queue &&) = delete;
+  Queue();
+
   ~Queue() override;
 
   // Atomically enqueue a single Message.
-  Result<> enqueue(Message &&message);
+  void enqueue(Message &&message);
 
   // Atomically enqueue a collection of Messages from a source STL container type between
   // the iterators [begin, end).
   template <class InputIt>
-  Result<> enqueue_all(InputIt begin, InputIt end)
+  void enqueue_all(InputIt begin, InputIt end)
   {
-    if (!is_healthy()) return health_err_result();
-
     Lock lock(mutex);
     std::move(begin, end, std::back_inserter(*active));
-    return ok_result();
   }
 
   // Atomically consume the current contents of the queue, emptying it.
   //
   // Returns a result containing unique_ptr to the vector of Messages, nullptr if no Messages were
   // present, or an error if the Queue is unhealthy.
-  Result<std::unique_ptr<std::vector<Message>>> accept_all();
+  std::unique_ptr<std::vector<Message>> accept_all();
 
   // Atomically report the number of items waiting on the queue.
   size_t size();
 
+  Queue(const Queue &) = delete;
+  Queue(Queue &&) = delete;
   Queue &operator=(const Queue &) = delete;
   Queue &operator=(Queue &&) = delete;
 
 private:
-  uv_mutex_t mutex{};
+  uv_mutex_t mutex;
   std::unique_ptr<std::vector<Message>> active;
 };
 

--- a/src/status.h
+++ b/src/status.h
@@ -4,8 +4,8 @@
 #include <iostream>
 #include <string>
 
-// Summarize the module's health. This includes information like the health of all Errable and SyncErrable
-// resources and the sizes of internal queues and buffers.
+// Summarize the module's health. This includes information like the health of all Errable resources and the sizes of
+// internal queues and buffers.
 class Status
 {
 public:

--- a/src/worker/linux/linux_worker_platform.cpp
+++ b/src/worker/linux/linux_worker_platform.cpp
@@ -23,11 +23,12 @@ using std::vector;
 class LinuxWorkerPlatform : public WorkerPlatform
 {
 public:
-  LinuxWorkerPlatform(WorkerThread *thread) :
-    WorkerPlatform(thread),
-    pipe("worker pipe"){
-      //
-    };
+  LinuxWorkerPlatform(WorkerThread *thread) : WorkerPlatform(thread)
+  {
+    report_errable(pipe);
+    report_errable(watch_registry);
+    freeze();
+  };
 
   // Inform the listen() loop that one or more commands are waiting from the main thread.
   Result<> wake() override { return pipe.signal(); }

--- a/src/worker/linux/linux_worker_platform.cpp
+++ b/src/worker/linux/linux_worker_platform.cpp
@@ -26,7 +26,7 @@ public:
   LinuxWorkerPlatform(WorkerThread *thread) : WorkerPlatform(thread)
   {
     report_errable(pipe);
-    report_errable(watch_registry);
+    report_errable(registry);
     freeze();
   };
 

--- a/src/worker/linux/pipe.h
+++ b/src/worker/linux/pipe.h
@@ -1,17 +1,15 @@
 #ifndef PIPE_H
 #define PIPE_H
 
-#include <string>
-
 #include "../../errable.h"
 #include "../../result.h"
 
 // RAII wrapper for a Linux pipe created with pipe(2). We don't care about the actual data transmitted.
-class Pipe : public SyncErrable
+class Pipe : public Errable
 {
 public:
   // Construct a new Pipe identified in Result<> errors with a specified name.
-  explicit Pipe(std::string &&name);
+  Pipe();
 
   // Deallocate and close() the underlying pipe file descriptor.
   ~Pipe() override;

--- a/src/worker/linux/watch_registry.cpp
+++ b/src/worker/linux/watch_registry.cpp
@@ -63,7 +63,7 @@ WatchRegistry::WatchRegistry()
   inotify_fd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
 
   if (inotify_fd == -1) {
-    report_error(errno_result("Unable to initialize inotify"));
+    report_if_error(errno_result("Unable to initialize inotify"));
   }
   freeze();
 }

--- a/src/worker/macos/macos_worker_platform.cpp
+++ b/src/worker/macos/macos_worker_platform.cpp
@@ -43,14 +43,12 @@ using std::unordered_map;
 class MacOSWorkerPlatform : public WorkerPlatform
 {
 public:
-  MacOSWorkerPlatform(WorkerThread *thread) : WorkerPlatform(thread){};
+  MacOSWorkerPlatform(WorkerThread *thread) : WorkerPlatform(thread) { freeze(); };
 
   ~MacOSWorkerPlatform() override = default;
 
   Result<> wake() override
   {
-    if (!is_healthy()) return health_err_result();
-
     if (command_source.empty() || run_loop.empty()) {
       return ok_result();
     }
@@ -63,8 +61,6 @@ public:
 
   Result<> listen() override
   {
-    if (!is_healthy()) return health_err_result();
-
     run_loop.set_from_get(CFRunLoopGetCurrent());
 
     CFRunLoopSourceContext command_context{
@@ -91,8 +87,6 @@ public:
     const string &root_path,
     bool recursive) override
   {
-    if (!is_healthy()) return health_err_result().propagate<bool>();
-
     ostream &logline = LOGGER << "Adding watcher for path " << root_path;
     if (!recursive) {
       logline << " (non-recursively)";
@@ -158,7 +152,6 @@ public:
 
   Result<bool> handle_remove_command(CommandID /*command_id*/, ChannelID channel_id) override
   {
-    if (!is_healthy()) return health_err_result().propagate<bool>();
     LOGGER << "Removing watcher for channel " << channel_id << "." << endl;
 
     auto maybe_sub = subscriptions.find(channel_id);

--- a/src/worker/worker_platform.h
+++ b/src/worker/worker_platform.h
@@ -16,8 +16,6 @@ class WorkerPlatform : public Errable
 public:
   static std::unique_ptr<WorkerPlatform> for_worker(WorkerThread *thread);
 
-  WorkerPlatform() : Errable("platform"){};
-
   ~WorkerPlatform() override = default;
 
   virtual Result<> wake() = 0;
@@ -33,12 +31,7 @@ public:
 
   virtual void populate_status(Status & /*status*/) {}
 
-  Result<> handle_commands()
-  {
-    if (!is_healthy()) return health_err_result();
-
-    return thread->handle_commands().propagate_as_void();
-  }
+  Result<> handle_commands() { return thread->handle_commands().propagate_as_void(); }
 
   WorkerPlatform(const WorkerPlatform &) = delete;
   WorkerPlatform(WorkerPlatform &&) = delete;
@@ -46,23 +39,16 @@ public:
   WorkerPlatform &operator=(WorkerPlatform &&) = delete;
 
 protected:
-  WorkerPlatform(WorkerThread *thread) : Errable("platform"), thread{thread}
+  WorkerPlatform(WorkerThread *thread) : thread{thread}
   {
     //
   }
 
-  Result<> emit(Message &&message)
-  {
-    if (!is_healthy()) return health_err_result();
-
-    return thread->emit(std::move(message));
-  }
+  Result<> emit(Message &&message) { return thread->emit(std::move(message)); }
 
   template <class InputIt>
   Result<> emit_all(InputIt begin, InputIt end)
   {
-    if (!is_healthy()) return health_err_result();
-
     return thread->emit_all(begin, end);
   }
 

--- a/src/worker/worker_thread.cpp
+++ b/src/worker/worker_thread.cpp
@@ -18,7 +18,8 @@ WorkerThread::WorkerThread(uv_async_t *main_callback) :
   Thread("worker thread", main_callback),
   platform{WorkerPlatform::for_worker(this)}
 {
-  //
+  report_errable(*platform);
+  freeze();
 }
 
 // Definition must be here to see the full definition of WorkerPlatform.
@@ -26,8 +27,6 @@ WorkerThread::~WorkerThread() = default;
 
 Result<> WorkerThread::wake()
 {
-  if (!is_healthy()) return health_err_result();
-
   return platform->wake();
 }
 
@@ -54,7 +53,7 @@ Result<Thread::CommandOutcome> WorkerThread::handle_status_command(const Command
   unique_ptr<Status> status{new Status()};
 
   status->worker_thread_state = state_name();
-  status->worker_thread_ok = get_error();
+  status->worker_thread_ok = get_message();
   status->worker_in_size = get_in_queue_size();
   status->worker_in_ok = get_in_queue_error();
   status->worker_out_size = get_out_queue_size();


### PR DESCRIPTION
SyncErrable is a relic of the synchronous `.status()` call. Because I needed to be able to read thread and queue Errable states from the main thread and the other threads, I had to synchronize access to the errored state of each resource, which is really expensive. Now that `.status()` is async from #79, I can cut out SyncErrable and simplify its interface a great deal.

I've also taken advantage of the fact that Errable states were _only_ being set within constructors. There's no reason to check `is_healthy()` in every single method if I can do it once after construction.