### PR TITLE
Handle rename of the watched root directory

### DIFF
--- a/src/polling/directory_record.cpp
+++ b/src/polling/directory_record.cpp
@@ -73,7 +73,11 @@ inline EntryKind kind_from_stat(const uv_stat_t &st)
   return KIND_UNKNOWN;
 }
 
-DirectoryRecord::DirectoryRecord(string &&prefix) : parent{nullptr}, name{move(prefix)}, populated{false}
+DirectoryRecord::DirectoryRecord(string &&prefix) :
+  parent{nullptr},
+  name{move(prefix)},
+  populated{false},
+  was_present{false}
 {
   //
 }
@@ -91,18 +95,23 @@ void DirectoryRecord::scan(BoundPollingIterator *it)
   string dir = path();
   int scan_err = uv_fs_scandir(nullptr, &scan_req.req, dir.c_str(), 0, nullptr);
   if (scan_err < 0) {
-    ostringstream msg;
-    msg << "Unable to scan directory " << dir << ": " << uv_strerror(scan_err);
-
     if (scan_err == UV_ENOENT || scan_err == UV_ENOTDIR || scan_err == UV_EACCES) {
-      // It's probably fine. Just log it.
-      // TODO: Maybe report a deletion if this is the top-level record?
-      LOGGER << msg.str() << "." << endl;
+      if (was_present) {
+        it->get_buffer().deleted(move(dir), KIND_DIRECTORY);
+        was_present = false;
+      }
     } else {
+      ostringstream msg;
+      msg << "Unable to scan directory " << dir << ": " << uv_strerror(scan_err);
       it->get_buffer().error(msg.str(), false);
     }
 
     return;
+  }
+
+  if (!was_present) {
+    it->get_buffer().created(string(dir), KIND_DIRECTORY);
+    was_present = true;
   }
 
   uv_dirent_t dirent{};

--- a/src/polling/directory_record.cpp
+++ b/src/polling/directory_record.cpp
@@ -15,7 +15,6 @@
 #include "polling_iterator.h"
 
 using std::dec;
-using std::endl;
 using std::hex;
 using std::move;
 using std::ostream;

--- a/src/polling/directory_record.cpp
+++ b/src/polling/directory_record.cpp
@@ -97,7 +97,7 @@ void DirectoryRecord::scan(BoundPollingIterator *it)
   if (scan_err < 0) {
     if (scan_err == UV_ENOENT || scan_err == UV_ENOTDIR || scan_err == UV_EACCES) {
       if (was_present) {
-        it->get_buffer().deleted(move(dir), KIND_DIRECTORY);
+        entry_deleted(it, dir, KIND_DIRECTORY);
         was_present = false;
       }
     } else {
@@ -110,7 +110,7 @@ void DirectoryRecord::scan(BoundPollingIterator *it)
   }
 
   if (!was_present) {
-    it->get_buffer().created(string(dir), KIND_DIRECTORY);
+    entry_created(it, dir, KIND_DIRECTORY);
     was_present = true;
   }
 

--- a/src/polling/directory_record.cpp
+++ b/src/polling/directory_record.cpp
@@ -272,7 +272,8 @@ size_t DirectoryRecord::count_entries() const
 DirectoryRecord::DirectoryRecord(DirectoryRecord *parent, string &&name) :
   parent{parent},
   name(move(name)),
-  populated{false}
+  populated{false},
+  was_present{false}
 {
   //
 }

--- a/src/polling/directory_record.h
+++ b/src/polling/directory_record.h
@@ -84,6 +84,10 @@ private:
   // against. Otherwise, we have nothing to compare against, so we shouldn't emit anything.
   bool populated;
 
+  // If true, this directory was present and scannable the last time it was encountered in the polling cycle. Used to
+  // prevent duplicate deletion events for missing directories.
+  bool was_present;
+
   // For great logging.
   friend std::ostream &operator<<(std::ostream &out, const DirectoryRecord &record)
   {

--- a/test/events/root-rename.test.js
+++ b/test/events/root-rename.test.js
@@ -20,7 +20,7 @@ const {EventMatcher} = require('../matcher');
       await fixture.after(this.currentTest)
     })
 
-    it('emits a deletion event for the root move itself', async function () {
+    it('emits a deletion event for the root move itself ^windows ^linux', async function () {
       const oldRoot = fixture.watchPath()
       const newRoot = fixture.fixturePath('new-root')
 
@@ -31,7 +31,7 @@ const {EventMatcher} = require('../matcher');
       ))
     })
 
-    it('does not emit events within the new root', async function () {
+    it('does not emit events within the new root ^windows ^linux', async function () {
       const oldRoot = fixture.watchPath()
       const oldFile = fixture.watchPath('some-file.txt')
       const newRoot = fixture.fixturePath('new-root')

--- a/test/events/root-rename.test.js
+++ b/test/events/root-rename.test.js
@@ -1,0 +1,53 @@
+const fs = require('fs-extra')
+
+const {Fixture} = require('../helper')
+const {EventMatcher} = require('../matcher');
+
+[false, true].forEach(poll => {
+  describe(`renaming the root with poll = ${poll}`, function () {
+    let fixture, matcher
+
+    beforeEach(async function () {
+      fixture = new Fixture()
+      await fixture.before()
+      await fixture.log()
+
+      matcher = new EventMatcher(fixture)
+      await matcher.watch([], {poll})
+    })
+
+    afterEach(async function () {
+      await fixture.after(this.currentTest)
+    })
+
+    it('emits a deletion event for the root move itself', async function () {
+      const oldRoot = fixture.watchPath()
+      const newRoot = fixture.fixturePath('new-root')
+
+      await fs.rename(oldRoot, newRoot)
+
+      await until('deletion event arrives', matcher.allEvents(
+        {action: 'deleted', kind: 'directory', path: oldRoot}
+      ))
+    })
+
+    it('does not emit events within the new root', async function () {
+      const oldRoot = fixture.watchPath()
+      const oldFile = fixture.watchPath('some-file.txt')
+      const newRoot = fixture.fixturePath('new-root')
+      const newFile = fixture.fixturePath('new-root', 'some-file.txt')
+
+      await fs.rename(oldRoot, newRoot)
+      await fs.appendFile(newFile, 'changed\n')
+
+      await until('deletion event arrives', matcher.allEvents(
+        {action: 'deleted', kind: 'directory', path: oldRoot}
+      ))
+
+      assert.isTrue(matcher.noEvents(
+        {path: oldFile},
+        {path: newFile}
+      ))
+    })
+  })
+})


### PR DESCRIPTION
If the root directory itself is renamed, emit a single `"deleted"` event for the old path and cease event delivery.