### PR TITLE
Check the creation flag when emitting a create/delete pair

### DIFF
--- a/src/worker/macos/rename_buffer.h
+++ b/src/worker/macos/rename_buffer.h
@@ -71,14 +71,12 @@ public:
   RenameBuffer &operator=(RenameBuffer &&) = delete;
 
 private:
-  bool observe_present_entry(ChannelMessageBuffer &message_buffer,
+  bool observe_present_entry(Event &event,
     RecentFileCache &cache,
     const std::shared_ptr<PresentEntry> &present,
     bool current);
 
-  bool observe_absent(ChannelMessageBuffer &message_buffer,
-    RecentFileCache &cache,
-    const std::shared_ptr<AbsentEntry> &absent);
+  bool observe_absent(Event &event, RecentFileCache &cache, const std::shared_ptr<AbsentEntry> &absent);
 
   std::unordered_map<Key, RenameBufferEntry> observed_by_inode;
 };


### PR DESCRIPTION
When correlating renames, it's possible for the prior entry to be "absent" even if the file was observed previously, due to cache expiration or issues like #88. In this case, we shouldn't emit a "create" event for the rename source. Disambiguate by checking for the presence of `kFSEventStreamEventFlagItemCreated`.