### PR TITLE
Update cache entries when a parent directory is renamed

### DIFF
--- a/src/worker/macos/recent_file_cache.cpp
+++ b/src/worker/macos/recent_file_cache.cpp
@@ -87,7 +87,7 @@ bool StatResult::could_be_rename_of(const StatResult &other) const
 
 bool StatResult::update_for_rename(const std::string &from_dir_path, const std::string &to_dir_path)
 {
-  if (path.rfind(from_dir_path, 0) == 0) {
+  if (path.size() > from_dir_path.size() && path.rfind(from_dir_path, 0) == 0) {
     path = to_dir_path + path.substr(from_dir_path.size());
     return true;
   }

--- a/src/worker/macos/recent_file_cache.h
+++ b/src/worker/macos/recent_file_cache.h
@@ -28,6 +28,8 @@ public:
 
   virtual bool could_be_rename_of(const StatResult &other) const;
 
+  bool update_for_rename(const std::string &from_dir_path, const std::string &to_dir_path);
+
   const std::string &get_path() const;
 
   EntryKind get_entry_kind() const;
@@ -112,6 +114,8 @@ public:
   void evict(const std::string &path);
 
   void evict(const std::shared_ptr<PresentEntry> &entry);
+
+  void update_for_rename(const std::string &from_dir_path, const std::string &to_dir_path);
 
   void apply();
 

--- a/src/worker/macos/rename_buffer.cpp
+++ b/src/worker/macos/rename_buffer.cpp
@@ -25,13 +25,17 @@ RenameBufferEntry::RenameBufferEntry(RenameBufferEntry &&original) noexcept :
   entry(move(original.entry)),
   current{original.current},
   age{original.age}
-{}
+{
+  //
+}
 
 RenameBufferEntry::RenameBufferEntry(std::shared_ptr<PresentEntry> entry, bool current) :
   entry{std::move(entry)},
   current{current},
   age{0}
-{}
+{
+  //
+}
 
 bool RenameBuffer::observe_event(Event &event, RecentFileCache &cache)
 {
@@ -181,4 +185,11 @@ shared_ptr<set<RenameBuffer::Key>> RenameBuffer::flush_unmatched(ChannelMessageB
   }
 
   return aged;
+}
+
+void RenameBuffer::update_for_rename(const string &from_dir_path, const string &to_dir_path)
+{
+  for (auto &pair : observed_by_inode) {
+    pair.second.update_for_rename(from_dir_path, to_dir_path);
+  }
 }

--- a/src/worker/macos/rename_buffer.cpp
+++ b/src/worker/macos/rename_buffer.cpp
@@ -127,10 +127,14 @@ bool RenameBuffer::observe_present_entry(Event &event,
 bool RenameBuffer::observe_absent(Event &event, RecentFileCache & /*cache*/, const std::shared_ptr<AbsentEntry> &absent)
 {
   LOGGER << "Unable to correlate rename from " << absent->get_path() << " without an inode." << endl;
-  if (event.flag_created()) {
+  if (event.flag_created() ^ event.flag_deleted()) {
+    // this entry was created just before being renamed or deleted just after being renamed.
     event.message_buffer().created(string(absent->get_path()), absent->get_entry_kind());
+    event.message_buffer().deleted(string(absent->get_path()), absent->get_entry_kind());
+  } else if (!event.flag_created() && !event.flag_deleted()) {
+    // former must have been evicted from the cache.
+    event.message_buffer().deleted(string(absent->get_path()), absent->get_entry_kind());
   }
-  event.message_buffer().deleted(string(absent->get_path()), absent->get_entry_kind());
   return true;
 }
 

--- a/src/worker/macos/rename_buffer.cpp
+++ b/src/worker/macos/rename_buffer.cpp
@@ -93,17 +93,31 @@ bool RenameBuffer::observe_present_entry(Event &event,
       // The former end is the "from" end and the current end is the "to" end.
       logline << "completed pair " << *existing.entry << " => " << *present << ": Emitting rename event." << endl;
 
+      EntryKind kind = present->get_entry_kind();
+      string from_path(existing.entry->get_path());
+      string to_path(present->get_path());
+
       cache.evict(existing.entry);
-      event.message_buffer().renamed(
-        string(existing.entry->get_path()), string(present->get_path()), present->get_entry_kind());
+      if (kind == KIND_DIRECTORY || kind == KIND_UNKNOWN) {
+        cache.update_for_rename(from_path, to_path);
+        update_for_rename(from_path, to_path);
+      }
+      event.message_buffer().renamed(move(from_path), move(to_path), kind);
       handled = true;
     } else if (existing.current && !current) {
       // The former end is the "to" end and the current end is the "from" end.
       logline << "completed pair " << *present << " => " << *existing.entry << ": Emitting rename event." << endl;
 
+      EntryKind kind = existing.entry->get_entry_kind();
+      string from_path(present->get_path());
+      string to_path(existing.entry->get_path());
+
       cache.evict(present);
-      event.message_buffer().renamed(
-        string(present->get_path()), string(existing.entry->get_path()), existing.entry->get_entry_kind());
+      if (kind == KIND_DIRECTORY || kind == KIND_UNKNOWN) {
+        cache.update_for_rename(from_path, to_path);
+        update_for_rename(from_path, to_path);
+      }
+      event.message_buffer().renamed(move(from_path), move(to_path), kind);
       handled = true;
     } else {
       // Either both entries are still present (hardlink, re-used inode?) or both are missing (rapidly renamed and

--- a/src/worker/macos/rename_buffer.cpp
+++ b/src/worker/macos/rename_buffer.cpp
@@ -100,7 +100,6 @@ bool RenameBuffer::observe_present_entry(Event &event,
       cache.evict(existing.entry);
       if (kind == KIND_DIRECTORY || kind == KIND_UNKNOWN) {
         cache.update_for_rename(from_path, to_path);
-        update_for_rename(from_path, to_path);
       }
       event.message_buffer().renamed(move(from_path), move(to_path), kind);
       handled = true;
@@ -115,7 +114,6 @@ bool RenameBuffer::observe_present_entry(Event &event,
       cache.evict(present);
       if (kind == KIND_DIRECTORY || kind == KIND_UNKNOWN) {
         cache.update_for_rename(from_path, to_path);
-        update_for_rename(from_path, to_path);
       }
       event.message_buffer().renamed(move(from_path), move(to_path), kind);
       handled = true;
@@ -199,11 +197,4 @@ shared_ptr<set<RenameBuffer::Key>> RenameBuffer::flush_unmatched(ChannelMessageB
   }
 
   return aged;
-}
-
-void RenameBuffer::update_for_rename(const string &from_dir_path, const string &to_dir_path)
-{
-  for (auto &pair : observed_by_inode) {
-    pair.second.update_for_rename(from_dir_path, to_dir_path);
-  }
 }

--- a/src/worker/macos/rename_buffer.h
+++ b/src/worker/macos/rename_buffer.h
@@ -23,11 +23,6 @@ public:
 
   ~RenameBufferEntry() = default;
 
-  bool update_for_rename(const std::string &from_dir_path, const std::string &to_dir_path)
-  {
-    return entry->update_for_rename(from_dir_path, to_dir_path);
-  }
-
   RenameBufferEntry(const RenameBufferEntry &) = delete;
   RenameBufferEntry &operator=(const RenameBufferEntry &) = delete;
   RenameBufferEntry &operator=(RenameBufferEntry &&) = delete;
@@ -69,8 +64,6 @@ public:
     const std::shared_ptr<std::set<Key>> &keys);
 
   size_t size() { return observed_by_inode.size(); }
-
-  void update_for_rename(const std::string &from_dir_path, const std::string &to_dir_path);
 
   RenameBuffer(const RenameBuffer &) = delete;
   RenameBuffer(RenameBuffer &&) = delete;

--- a/src/worker/macos/rename_buffer.h
+++ b/src/worker/macos/rename_buffer.h
@@ -23,6 +23,11 @@ public:
 
   ~RenameBufferEntry() = default;
 
+  bool update_for_rename(const std::string &from_dir_path, const std::string &to_dir_path)
+  {
+    return entry->update_for_rename(from_dir_path, to_dir_path);
+  }
+
   RenameBufferEntry(const RenameBufferEntry &) = delete;
   RenameBufferEntry &operator=(const RenameBufferEntry &) = delete;
   RenameBufferEntry &operator=(RenameBufferEntry &&) = delete;
@@ -64,6 +69,8 @@ public:
     const std::shared_ptr<std::set<Key>> &keys);
 
   size_t size() { return observed_by_inode.size(); }
+
+  void update_for_rename(const std::string &from_dir_path, const std::string &to_dir_path);
 
   RenameBuffer(const RenameBuffer &) = delete;
   RenameBuffer(RenameBuffer &&) = delete;

--- a/test/events/parent-rename.test.js
+++ b/test/events/parent-rename.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs-extra')
+
+const {Fixture} = require('../helper')
+const {EventMatcher} = require('../matcher')
+
+// These cases interfere with the caches on MacOS, but other platforms should handle them correctly as well.
+describe.only('when a parent directory is renamed', function () {
+  let fixture, matcher
+  let originalParentDir, originalFile
+  let finalParentDir, finalFile
+
+  beforeEach(async function () {
+    fixture = new Fixture()
+    await fixture.before()
+    await fixture.log()
+
+    originalParentDir = fixture.watchPath('parent-0')
+    originalFile = fixture.watchPath('parent-0', 'file.txt')
+    finalParentDir = fixture.watchPath('parent-1')
+    finalFile = fixture.watchPath('parent-1', 'file.txt')
+
+    await fs.mkdir(originalParentDir)
+    await fs.writeFile(originalFile, 'contents\n')
+
+    matcher = new EventMatcher(fixture)
+    await matcher.watch([], {})
+
+    await fs.rename(originalParentDir, finalParentDir)
+    await until('the rename event arrives', matcher.allEvents(
+      {action: 'renamed', kind: 'directory', oldPath: originalParentDir, path: finalParentDir}
+    ))
+  })
+
+  afterEach(async function () {
+    await fixture.after(this.currentTest)
+  })
+
+  it('tracks the file rename', async function () {
+    const changedFile = fixture.watchPath('parent-1', 'file-1.txt')
+    await fs.rename(finalFile, changedFile)
+
+    await until('the rename event arrives', matcher.allEvents(
+      {action: 'renamed', kind: 'file', oldPath: finalFile, path: changedFile}
+    ))
+  })
+})

--- a/test/events/parent-rename.test.js
+++ b/test/events/parent-rename.test.js
@@ -35,7 +35,7 @@ describe('when a parent directory is renamed', function () {
     await fixture.after(this.currentTest)
   })
 
-  it('tracks the file rename', async function () {
+  it('tracks the file rename ^linux', async function () {
     const changedFile = fixture.watchPath('parent-1', 'file-1.txt')
     await fs.rename(finalFile, changedFile)
 

--- a/test/events/parent-rename.test.js
+++ b/test/events/parent-rename.test.js
@@ -4,7 +4,7 @@ const {Fixture} = require('../helper')
 const {EventMatcher} = require('../matcher')
 
 // These cases interfere with the caches on MacOS, but other platforms should handle them correctly as well.
-describe.only('when a parent directory is renamed', function () {
+describe('when a parent directory is renamed', function () {
   let fixture, matcher
   let originalParentDir, originalFile
   let finalParentDir, finalFile

--- a/test/events/rapid.test.js
+++ b/test/events/rapid.test.js
@@ -67,6 +67,56 @@ const {EventMatcher} = require('../matcher');
           ))
         }
       })
+
+      it('understands rapid rename and deletion events', async function () {
+        const originalPath = fixture.watchPath('created.txt')
+        const finalPath = fixture.watchPath('final.txt')
+
+        await fs.writeFile(originalPath, 'contents\n')
+        await until('creation event arrives', matcher.allEvents(
+          {action: 'created', kind: 'file', path: originalPath}
+        ))
+
+        await fs.rename(originalPath, finalPath)
+        await fs.remove(finalPath)
+
+        if (process.platform === 'darwin') {
+          await until('creation and deletion events arrive', matcher.allEvents(
+            {action: 'deleted', kind: 'file', path: originalPath},
+            {action: 'created', kind: 'file', path: finalPath},
+            {action: 'deleted', kind: 'file', path: finalPath}
+          ))
+        } else {
+          await until('rename and deletion events arrive', matcher.allEvents(
+            {action: 'created', kind: 'file', path: originalPath},
+            {action: 'renamed', kind: 'file', oldPath: originalPath, path: finalPath}
+          ))
+        }
+      })
+
+      it('understands rapid creation, rename, and deletion events', async function () {
+        const originalPath = fixture.watchPath('created.txt')
+        const finalPath = fixture.watchPath('final.txt')
+
+        await fs.writeFile(originalPath, 'contents\n')
+        await fs.rename(originalPath, finalPath)
+        await fs.remove(finalPath)
+
+        if (process.platform === 'darwin') {
+          await until('creation and deletion events arrive', matcher.allEvents(
+            {action: 'created', kind: 'file', path: originalPath},
+            {action: 'deleted', kind: 'file', path: originalPath},
+            {action: 'created', kind: 'file', path: finalPath},
+            {action: 'deleted', kind: 'file', path: finalPath}
+          ))
+        } else {
+          await until('creation, rename, and deletion events arrive', matcher.allEvents(
+            {action: 'created', kind: 'file', path: originalPath},
+            {action: 'renamed', kind: 'file', oldPath: originalPath, path: finalPath},
+            {action: 'deleted', kind: 'file', path: finalPath}
+          ))
+        }
+      })
     }
 
     it('correlates rapid file rename events', async function () {

--- a/test/events/rapid.test.js
+++ b/test/events/rapid.test.js
@@ -88,8 +88,8 @@ const {EventMatcher} = require('../matcher');
           ))
         } else {
           await until('rename and deletion events arrive', matcher.allEvents(
-            {action: 'created', kind: 'file', path: originalPath},
-            {action: 'renamed', kind: 'file', oldPath: originalPath, path: finalPath}
+            {action: 'renamed', oldPath: originalPath, path: finalPath},
+            {action: 'deleted', path: finalPath}
           ))
         }
       })

--- a/test/events/rapid.test.js
+++ b/test/events/rapid.test.js
@@ -111,9 +111,9 @@ const {EventMatcher} = require('../matcher');
           ))
         } else {
           await until('creation, rename, and deletion events arrive', matcher.allEvents(
-            {action: 'created', kind: 'file', path: originalPath},
-            {action: 'renamed', kind: 'file', oldPath: originalPath, path: finalPath},
-            {action: 'deleted', kind: 'file', path: finalPath}
+            {action: 'created', path: originalPath},
+            {action: 'renamed', oldPath: originalPath, path: finalPath},
+            {action: 'deleted', path: finalPath}
           ))
         }
       })


### PR DESCRIPTION
On MacOS, update cached entries within a directory when the directory is renamed. Fixes #88.