### PR TITLE
Additional parent directory rename cases

### DIFF
--- a/src/worker/macos/batch_handler.cpp
+++ b/src/worker/macos/batch_handler.cpp
@@ -49,9 +49,6 @@ bool Event::update_for_rename(const string &from_dir_path, const string &to_dir_
   const string &stat_path = get_stat_path();
   if (stat_path.size() > from_dir_path.size() && stat_path.rfind(from_dir_path, 0) == 0) {
     updated_event_path = to_dir_path + stat_path.substr(from_dir_path.size());
-    LOGGER << "FROM " << stat_path << " TO " << updated_event_path << "\n"
-           << " from_dir_path=[" << from_dir_path << "]"
-           << " to_dir_path=[" << to_dir_path << "]" << endl;
     return true;
   }
 

--- a/src/worker/macos/batch_handler.cpp
+++ b/src/worker/macos/batch_handler.cpp
@@ -26,7 +26,6 @@ using std::string;
 Event::Event(BatchHandler &batch, std::string &&event_path, FSEventStreamEventFlags flags) :
   handler{batch},
   event_path{move(event_path)},
-  updated_event_path{},
   flags{flags},
   former{nullptr},
   current{nullptr}
@@ -221,8 +220,7 @@ BatchHandler::BatchHandler(ChannelMessageBuffer &message_buffer,
   message_buffer{message_buffer},
   rename_buffer{rename_buffer},
   recursive{recursive},
-  root_path{root_path},
-  deferred{}
+  root_path{root_path}
 {
   //
 }

--- a/src/worker/macos/batch_handler.cpp
+++ b/src/worker/macos/batch_handler.cpp
@@ -23,42 +23,40 @@ using std::move;
 using std::ostream;
 using std::string;
 
-BatchHandler::BatchHandler(ChannelMessageBuffer &message_buffer,
-  RecentFileCache &cache,
-  RenameBuffer &rename_buffer,
-  bool recursive,
-  const string &root_path) :
-  cache{cache},
-  message_buffer{message_buffer},
-  rename_buffer{rename_buffer},
-  recursive{recursive},
-  root_path{root_path}
-{
-  //
-}
-
-void BatchHandler::event(string &&event_path, FSEventStreamEventFlags flags)
-{
-  Event event(*this, move(event_path), flags);
-
-  if (event.skip_recursive_event()) return;
-  event.collect_info();
-  event.report();
-
-  if (event.emit_if_unambiguous()) return;
-  if (event.emit_if_rename()) return;
-  if (event.emit_if_absent()) return;
-  event.emit_if_present();
-}
-
 Event::Event(BatchHandler &batch, std::string &&event_path, FSEventStreamEventFlags flags) :
   handler{batch},
   event_path{move(event_path)},
+  updated_event_path{},
   flags{flags},
   former{nullptr},
   current{nullptr}
 {
   //
+}
+
+Event::Event(Event &&original) noexcept :
+  handler{original.handler},
+  event_path{move(original.event_path)},
+  updated_event_path{move(original.updated_event_path)},
+  flags{original.flags},
+  former{move(original.former)},
+  current{move(original.current)}
+{
+  //
+}
+
+bool Event::update_for_rename(const string &from_dir_path, const string &to_dir_path)
+{
+  const string &stat_path = get_stat_path();
+  if (stat_path.size() > from_dir_path.size() && stat_path.rfind(from_dir_path, 0) == 0) {
+    updated_event_path = to_dir_path + stat_path.substr(from_dir_path.size());
+    LOGGER << "FROM " << stat_path << " TO " << updated_event_path << "\n"
+           << " from_dir_path=[" << from_dir_path << "]"
+           << " to_dir_path=[" << to_dir_path << "]" << endl;
+    return true;
+  }
+
+  return false;
 }
 
 bool Event::skip_recursive_event()
@@ -73,14 +71,25 @@ bool Event::skip_recursive_event()
 
 void Event::collect_info()
 {
-  former = cache().former_at_path(event_path, flag_file(), flag_directory());
-  current = cache().current_at_path(event_path, flag_file(), flag_directory());
+  if (!former) {
+    former = cache().former_at_path(event_path, flag_file(), flag_directory());
+  }
+  current = cache().current_at_path(get_stat_path(), flag_file(), flag_directory());
+}
+
+bool Event::should_defer()
+{
+  return flag_renamed() && former->is_absent() && current->is_absent();
 }
 
 void Event::report()
 {
   ostream &logline = LOGGER;
-  logline << "Event at [" << event_path << "] flags " << hex << flags << dec << " [";
+  logline << "Event at [" << event_path << "] ";
+  if (!updated_event_path.empty()) {
+    logline << " (now at [" << updated_event_path << "]) ";
+  }
+  logline << "flags " << hex << flags << dec << " [";
 
   if ((flags & kFSEventStreamEventFlagMustScanSubDirs) != 0) logline << " MustScanSubDirs";
   if ((flags & kFSEventStreamEventFlagUserDropped) != 0) logline << " UserDropped";
@@ -141,7 +150,7 @@ bool Event::emit_if_unambiguous()
 bool Event::emit_if_rename()
 {
   if (flag_renamed()) {
-    return rename_buffer().observe_event(*this, cache());
+    return rename_buffer().observe_event(*this, handler);
   }
 
   return false;
@@ -155,17 +164,17 @@ bool Event::emit_if_absent()
     && flag_created()) {
     // Entry was last seen as a directory, but the latest event has it flagged as a file (or vice versa).
     // The directory must have been deleted.
-    message_buffer().deleted(string(former->get_path()), former->get_entry_kind());
-    message_buffer().created(string(current->get_path()), current->get_entry_kind());
+    message_buffer().deleted(string(event_path), former->get_entry_kind());
+    message_buffer().created(string(event_path), current->get_entry_kind());
   } else if (former->is_absent() && flag_created()) {
-    // Entry has not been seen before, so this must be its creation event.
-    message_buffer().created(string(current->get_path()), current->get_entry_kind());
+    // Entry has not been seen before and the Created flag was set, so this must be its creation event.
+    message_buffer().created(string(event_path), current->get_entry_kind());
   }
 
   // It isn't there now, so it must have been deleted.
   if (flag_deleted()) {
-    message_buffer().deleted(string(current->get_path()), current->get_entry_kind());
-    cache().evict(current->get_path());
+    message_buffer().deleted(string(event_path), current->get_entry_kind());
+    cache().evict(event_path);
   }
   return true;
 }
@@ -179,26 +188,107 @@ bool Event::emit_if_present()
     if (flag_deleted() && flag_created()) {
       // Rapid creation and deletion. There may be a lost modification event just before deletion or just after
       // recreation.
-      message_buffer().deleted(string(former->get_path()), former->get_entry_kind());
-      message_buffer().created(string(current->get_path()), current->get_entry_kind());
+      message_buffer().deleted(string(event_path), former->get_entry_kind());
+      message_buffer().created(string(event_path), current->get_entry_kind());
     } else if (flag_modified()) {
       // Modification of an existing entry.
-      message_buffer().modified(string(current->get_path()), current->get_entry_kind());
+      message_buffer().modified(string(event_path), current->get_entry_kind());
     }
   } else {
     // This *is* the first time an event has been seen at this path.
     if (flag_deleted() && flag_created()) {
       // The only way for the deletion flag to be set on an entry we haven't seen before is for the entry to
       // be rapidly created, deleted, and created again.
-      message_buffer().created(string(former->get_path()), former->get_entry_kind());
-      message_buffer().deleted(string(former->get_path()), former->get_entry_kind());
-      message_buffer().created(string(current->get_path()), current->get_entry_kind());
+      message_buffer().created(string(event_path), former->get_entry_kind());
+      message_buffer().deleted(string(event_path), former->get_entry_kind());
+      message_buffer().created(string(event_path), current->get_entry_kind());
     } else if (flag_created()) {
       // Otherwise, it must have been created. This may conceal a separate modification event just after
       // the entry's creation.
-      message_buffer().created(string(current->get_path()), current->get_entry_kind());
+      message_buffer().created(string(event_path), current->get_entry_kind());
     }
   }
 
   return true;
+}
+
+BatchHandler::BatchHandler(ChannelMessageBuffer &message_buffer,
+  RecentFileCache &cache,
+  RenameBuffer &rename_buffer,
+  bool recursive,
+  const string &root_path) :
+  cache{cache},
+  message_buffer{message_buffer},
+  rename_buffer{rename_buffer},
+  recursive{recursive},
+  root_path{root_path},
+  deferred{}
+{
+  //
+}
+
+void BatchHandler::event(string &&event_path, FSEventStreamEventFlags flags)
+{
+  Event event(*this, move(event_path), flags);
+
+  if (event.skip_recursive_event()) return;
+  event.collect_info();
+  if (event.should_defer()) {
+    deferred.emplace_back(move(event));
+    return;
+  }
+
+  event.report();
+  if (event.emit_if_unambiguous()) return;
+  if (event.emit_if_rename()) return;
+  if (event.emit_if_absent()) return;
+  event.emit_if_present();
+}
+
+bool BatchHandler::update_for_rename(const string &from_dir_path, const string &to_dir_path)
+{
+  cache.update_for_rename(from_dir_path, to_dir_path);
+
+  bool at_least_one = false;
+  for (Event &each : deferred) {
+    if (each.update_for_rename(from_dir_path, to_dir_path)) at_least_one = true;
+  }
+  return at_least_one;
+}
+
+void BatchHandler::handle_deferred()
+{
+  bool at_least_one = true;
+
+  while (at_least_one) {
+    at_least_one = false;
+
+    auto it = deferred.begin();
+    while (it != deferred.end()) {
+      if (!it->needs_updated_info()) {
+        ++it;
+        continue;
+      }
+
+      it->collect_info();
+      if (it->should_defer()) {
+        ++it;
+        continue;
+      }
+
+      at_least_one = true;
+      it->report();
+      it->emit_if_rename();
+      auto to_erase = it;
+      ++it;
+      deferred.erase(to_erase);
+    }
+  }
+
+  // Flush the rest.
+  for (Event &each : deferred) {
+    each.report();
+    each.emit_if_rename();
+  }
+  deferred.clear();
 }

--- a/src/worker/macos/batch_handler.h
+++ b/src/worker/macos/batch_handler.h
@@ -2,8 +2,8 @@
 #define EVENT_HANDLER_H
 
 #include <CoreServices/CoreServices.h>
+#include <list>
 #include <string>
-#include <vector>
 
 #include "../../message.h"
 #include "../../message_buffer.h"
@@ -11,37 +11,15 @@
 #include "recent_file_cache.h"
 #include "rename_buffer.h"
 
-class BatchHandler
-{
-public:
-  BatchHandler(ChannelMessageBuffer &message_buffer,
-    RecentFileCache &cache,
-    RenameBuffer &rename_buffer,
-    bool recursive,
-    const std::string &root_path);
-
-  ~BatchHandler() = default;
-
-  void event(std::string &&event_path, FSEventStreamEventFlags flags);
-
-  BatchHandler(const BatchHandler &) = delete;
-  BatchHandler(BatchHandler &&) = delete;
-  BatchHandler &operator=(const BatchHandler &) = delete;
-  BatchHandler &operator=(BatchHandler &&) = delete;
-
-private:
-  RecentFileCache &cache;
-  ChannelMessageBuffer &message_buffer;
-  RenameBuffer &rename_buffer;
-  bool recursive;
-  const std::string &root_path;
-
-  friend class Event;
-};
+class BatchHandler;
 
 class Event
 {
 public:
+  Event(BatchHandler &batch, std::string &&event_path, FSEventStreamEventFlags flags);
+
+  Event(Event &&original) noexcept;
+
   ~Event() = default;
 
   bool flag_created() { return (flags & CREATE_FLAGS) != 0; }
@@ -56,31 +34,38 @@ public:
 
   bool flag_directory() { return (flags & IS_DIRECTORY) != 0; }
 
-  bool is_recursive() { return handler.recursive; }
+  bool is_recursive();
 
-  const std::string &root_path() { return handler.root_path; }
+  const std::string &root_path();
 
-  ChannelMessageBuffer &message_buffer() { return handler.message_buffer; }
+  ChannelMessageBuffer &message_buffer();
 
-  RecentFileCache &cache() { return handler.cache; }
+  RecentFileCache &cache();
 
-  RenameBuffer &rename_buffer() { return handler.rename_buffer; }
+  RenameBuffer &rename_buffer();
+
+  const std::string &get_event_path() { return event_path; }
+
+  const std::string &get_stat_path() { return updated_event_path.empty() ? event_path : updated_event_path; }
 
   const std::shared_ptr<StatResult> &get_former() { return former; }
 
   const std::shared_ptr<StatResult> &get_current() { return current; }
 
+  bool update_for_rename(const std::string &from_dir_path, const std::string &to_dir_path);
+
+  bool needs_updated_info() { return !current || (get_stat_path() != current->get_path()); };
+
   Event(const Event &) = delete;
-  Event(Event &&) = delete;
   Event &operator=(const Event &) = delete;
   Event &operator=(Event &&) = delete;
 
 private:
-  Event(BatchHandler &batch, std::string &&event_path, FSEventStreamEventFlags flags);
-
   bool skip_recursive_event();
 
   void collect_info();
+
+  bool should_defer();
 
   void report();
 
@@ -94,6 +79,7 @@ private:
 
   BatchHandler &handler;
   std::string event_path;
+  std::string updated_event_path;
   FSEventStreamEventFlags flags;
 
   std::shared_ptr<StatResult> former;
@@ -101,5 +87,65 @@ private:
 
   friend class BatchHandler;
 };
+
+class BatchHandler
+{
+public:
+  BatchHandler(ChannelMessageBuffer &message_buffer,
+    RecentFileCache &cache,
+    RenameBuffer &rename_buffer,
+    bool recursive,
+    const std::string &root_path);
+
+  ~BatchHandler() = default;
+
+  void event(std::string &&event_path, FSEventStreamEventFlags flags);
+
+  bool update_for_rename(const std::string &from_dir_path, const std::string &to_dir_path);
+
+  void handle_deferred();
+
+  BatchHandler(const BatchHandler &) = delete;
+  BatchHandler(BatchHandler &&) = delete;
+  BatchHandler &operator=(const BatchHandler &) = delete;
+  BatchHandler &operator=(BatchHandler &&) = delete;
+
+private:
+  RecentFileCache &cache;
+  ChannelMessageBuffer &message_buffer;
+  RenameBuffer &rename_buffer;
+  bool recursive;
+  const std::string &root_path;
+  std::list<Event> deferred;
+
+  friend class Event;
+};
+
+// Inline event methods that need the full BatchHandler type.
+
+inline bool Event::is_recursive()
+{
+  return handler.recursive;
+}
+
+inline const std::string &Event::root_path()
+{
+  return handler.root_path;
+}
+
+inline ChannelMessageBuffer &Event::message_buffer()
+{
+  return handler.message_buffer;
+}
+
+inline RecentFileCache &Event::cache()
+{
+  return handler.cache;
+}
+
+inline RenameBuffer &Event::rename_buffer()
+{
+  return handler.rename_buffer;
+}
 
 #endif

--- a/src/worker/macos/macos_worker_platform.cpp
+++ b/src/worker/macos/macos_worker_platform.cpp
@@ -209,6 +209,7 @@ public:
     for (size_t i = 0; i < num_events; i++) {
       handler.event(string(paths[i]), event_flags[i]);
     }
+    handler.handle_deferred();
     cache.apply();
 
     shared_ptr<set<RenameBuffer::Key>> out = rename_buffer.flush_unmatched(message_buffer);

--- a/src/worker/macos/rename_buffer.cpp
+++ b/src/worker/macos/rename_buffer.cpp
@@ -29,9 +29,9 @@ RenameBufferEntry::RenameBufferEntry(RenameBufferEntry &&original) noexcept :
   //
 }
 
-RenameBufferEntry::RenameBufferEntry(shared_ptr<PresentEntry> entry, const string &event_path, bool current) :
+RenameBufferEntry::RenameBufferEntry(shared_ptr<PresentEntry> entry, string event_path, bool current) :
   entry{move(entry)},
-  event_path{event_path},
+  event_path{move(event_path)},
   current{current},
   age{0}
 {

--- a/src/worker/macos/rename_buffer.h
+++ b/src/worker/macos/rename_buffer.h
@@ -15,6 +15,9 @@
 // Forward declaration to be able to accept an Event argument
 class Event;
 
+// Forward declaration to be able to accept a BatchHandler argument
+class BatchHandler;
+
 // Filesystem entry that was flagged as participating in a rename by a received filesystem event.
 class RenameBufferEntry
 {
@@ -28,9 +31,10 @@ public:
   RenameBufferEntry &operator=(RenameBufferEntry &&) = delete;
 
 private:
-  RenameBufferEntry(std::shared_ptr<PresentEntry> entry, bool current);
+  RenameBufferEntry(std::shared_ptr<PresentEntry> entry, const std::string &event_path, bool current);
 
   std::shared_ptr<PresentEntry> entry;
+  std::string event_path;
   bool current;
   size_t age;
 
@@ -50,7 +54,7 @@ public:
   // Observe a rename event for a filesystem event. Deduce the matching side of the rename, if possible,
   // based on the previous and currently observed state of the entry at that path. Return "true" if the event
   // is consumed, or "false" if it should be treated as something other than a rename.
-  bool observe_event(Event &event, RecentFileCache &cache);
+  bool observe_event(Event &event, BatchHandler &batch);
 
   // Enqueue creation and removal events for any buffer entries that have remained unpaired through two consecutive
   // event batches.
@@ -72,11 +76,11 @@ public:
 
 private:
   bool observe_present_entry(Event &event,
-    RecentFileCache &cache,
+    BatchHandler &batch,
     const std::shared_ptr<PresentEntry> &present,
     bool current);
 
-  bool observe_absent(Event &event, RecentFileCache &cache, const std::shared_ptr<AbsentEntry> &absent);
+  bool observe_absent(Event &event, BatchHandler &batch, const std::shared_ptr<AbsentEntry> &absent);
 
   std::unordered_map<Key, RenameBufferEntry> observed_by_inode;
 };

--- a/src/worker/macos/rename_buffer.h
+++ b/src/worker/macos/rename_buffer.h
@@ -31,7 +31,7 @@ public:
   RenameBufferEntry &operator=(RenameBufferEntry &&) = delete;
 
 private:
-  RenameBufferEntry(std::shared_ptr<PresentEntry> entry, const std::string &event_path, bool current);
+  RenameBufferEntry(std::shared_ptr<PresentEntry> entry, std::string event_path, bool current);
 
   std::shared_ptr<PresentEntry> entry;
   std::string event_path;


### PR DESCRIPTION
A continuation of the work from #90, because spurious events are still being generated in watcher-stress.

The case that's causing the most problems is when:

1. A file `/root/parent-0/child-0.txt` is renamed to `/root/parent-0/child-1.txt`.
2. The parent directory `/root/parent-0` is renamed to `/root/parent-1`.
3. A single event batch containing both events is received by the watcher after both operations complete.

When the rename event for `child-0.txt` is processed, the `lstat()` call fails, because its path is no longer valid and we haven't seen the directory rename yet. This triggers the "absent :point_right: absent" case in the RenameBuffer, which infers a spurious deletion event.