### PR TITLE
Enable the last nonrecursive watcher test on Windows

### DIFF
--- a/test/events/nonrecursive.test.js
+++ b/test/events/nonrecursive.test.js
@@ -50,7 +50,7 @@ const {EventMatcher} = require('../matcher');
       ))
     })
 
-    it('ignores events for entries within a subdirectory ^windows', async function () {
+    it('ignores events for entries within a subdirectory', async function () {
       const flagFile = fixture.watchPath('file0.txt')
       const file1Path = fixture.watchPath('subdir-0', 'file1.txt')
       const file2Path = fixture.watchPath('subdir-0', 'file2.txt')

--- a/test/events/parent-rename.test.js
+++ b/test/events/parent-rename.test.js
@@ -64,7 +64,7 @@ describe('when a parent directory is renamed', function () {
     await fs.rename(originalParentDir, finalParentDir)
 
     await until('the rename events arrive', matcher.allEvents(
-      {action: 'renamed', kind: 'file', oldPath: originalFile, path: changedFile},
+      {action: 'renamed', oldPath: originalFile, path: changedFile},
       {action: 'renamed', kind: 'directory', oldPath: originalParentDir, path: finalParentDir}
     ))
   })


### PR DESCRIPTION
It passes for me here, even with 100 iterations. I forget why it was disabled to begin with?