### PR TITLE
Correlated renames split across batches on Windows

### DIFF
--- a/src/worker/windows/subscription.cpp
+++ b/src/worker/windows/subscription.cpp
@@ -33,7 +33,8 @@ Subscription::Subscription(ChannelID channel,
   recursive{recursive},
   buffer_size{DEFAULT_BUFFER_SIZE},
   buffer{new BYTE[buffer_size]},
-  written{new BYTE[buffer_size]}
+  written{new BYTE[buffer_size]},
+  old_path_seen{false}
 {
   ZeroMemory(&overlapped, sizeof(OVERLAPPED));
   overlapped.hEvent = this;

--- a/src/worker/windows/subscription.h
+++ b/src/worker/windows/subscription.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <utility>
 
 #include "../../message.h"
 #include "../../result.h"
@@ -43,6 +44,14 @@ public:
 
   const bool &is_terminating() const { return terminating; }
 
+  const std::string &get_old_path() const { return old_path; }
+
+  void set_old_path(std::string &&old_path) { this->old_path = std::move(old_path); }
+
+  const bool &was_old_path_seen() const { return old_path_seen; }
+
+  void set_old_path_seen(bool old_path_seen) { this->old_path_seen = old_path_seen; }
+
 private:
   CommandID command;
   ChannelID channel;
@@ -57,6 +66,9 @@ private:
   DWORD buffer_size;
   std::unique_ptr<BYTE[]> buffer;
   std::unique_ptr<BYTE[]> written;
+
+  std::string old_path;
+  bool old_path_seen;
 };
 
 #endif

--- a/src/worker/windows/subscription.h
+++ b/src/worker/windows/subscription.h
@@ -44,13 +44,24 @@ public:
 
   const bool &is_terminating() const { return terminating; }
 
+  void remember_old_path(std::string &&old_path, EntryKind kind)
+  {
+    this->old_path = std::move(old_path);
+    this->old_path_kind = kind;
+    this->old_path_seen = true;
+  }
+
+  void clear_old_path() {
+    old_path.clear();
+    old_path_kind = KIND_UNKNOWN;
+    old_path_seen = false;
+  }
+
   const std::string &get_old_path() const { return old_path; }
 
-  void set_old_path(std::string &&old_path) { this->old_path = std::move(old_path); }
+  const EntryKind &get_old_path_kind() const { return old_path_kind; }
 
   const bool &was_old_path_seen() const { return old_path_seen; }
-
-  void set_old_path_seen(bool old_path_seen) { this->old_path_seen = old_path_seen; }
 
 private:
   CommandID command;
@@ -68,6 +79,7 @@ private:
   std::unique_ptr<BYTE[]> written;
 
   std::string old_path;
+  EntryKind old_path_kind;
   bool old_path_seen;
 };
 

--- a/src/worker/windows/subscription.h
+++ b/src/worker/windows/subscription.h
@@ -51,7 +51,8 @@ public:
     this->old_path_seen = true;
   }
 
-  void clear_old_path() {
+  void clear_old_path()
+  {
     old_path.clear();
     old_path_kind = KIND_UNKNOWN;
     old_path_seen = false;

--- a/src/worker/windows/windows_worker_platform.cpp
+++ b/src/worker/windows/windows_worker_platform.cpp
@@ -355,6 +355,7 @@ private:
         if (sub->was_old_path_seen()) {
           // Old name received first
           logline << kind << "." << endl;
+          cache.update_for_rename(sub->get_old_path(), path);
           messages.renamed(string(sub->get_old_path()), move(path), kind);
           sub->set_old_path_seen(false);
         } else {

--- a/src/worker/windows/windows_worker_platform.cpp
+++ b/src/worker/windows/windows_worker_platform.cpp
@@ -347,17 +347,20 @@ private:
         break;
       case FILE_ACTION_RENAMED_OLD_NAME:
         logline << "FILE_ACTION_RENAMED_OLD_NAME " << kind << "." << endl;
-        sub->set_old_path_seen(true);
-        sub->set_old_path(move(path));
+        sub->remember_old_path(move(path), kind);
         break;
       case FILE_ACTION_RENAMED_NEW_NAME:
         logline << "FILE_ACTION_RENAMED_NEW_NAME ";
         if (sub->was_old_path_seen()) {
           // Old name received first
+          if (kind == KIND_UNKNOWN) {
+            kind = sub->get_old_path_kind();
+          }
+
           logline << kind << "." << endl;
           cache.update_for_rename(sub->get_old_path(), path);
           messages.renamed(string(sub->get_old_path()), move(path), kind);
-          sub->set_old_path_seen(false);
+          sub->clear_old_path();
         } else {
           // No old name. Treat it as a creation
           logline << "(unpaired) " << kind << "." << endl;

--- a/src/worker/windows/windows_worker_platform.cpp
+++ b/src/worker/windows/windows_worker_platform.cpp
@@ -329,25 +329,43 @@ private:
     }
     EntryKind kind = stat->get_entry_kind();
 
+    ostream &logline = LOGGER;
+    logline << "Event at [" << path << "] ";
+
     switch (info->Action) {
-      case FILE_ACTION_ADDED: messages.created(move(path), kind); break;
-      case FILE_ACTION_MODIFIED: messages.modified(move(path), kind); break;
-      case FILE_ACTION_REMOVED: messages.deleted(move(path), kind); break;
+      case FILE_ACTION_ADDED:
+        logline << "FILE_ACTION_ADDED " << kind << "." << endl;
+        messages.created(move(path), kind);
+        break;
+      case FILE_ACTION_MODIFIED:
+        logline << "FILE_ACTION_MODIFIED " << kind << "." << endl;
+        messages.modified(move(path), kind);
+        break;
+      case FILE_ACTION_REMOVED:
+        logline << "FILE_ACTION_REMOVED " << kind << "." << endl;
+        messages.deleted(move(path), kind);
+        break;
       case FILE_ACTION_RENAMED_OLD_NAME:
+        logline << "FILE_ACTION_RENAMED_OLD_NAME " << kind << "." << endl;
         old_path_seen = true;
         old_path = move(path);
         break;
       case FILE_ACTION_RENAMED_NEW_NAME:
+        logline << "FILE_ACTION_RENAMED_NEW_NAME ";
         if (old_path_seen) {
           // Old name received first
+          logline << kind << "." << endl;
           messages.renamed(move(old_path), move(path), kind);
           old_path_seen = false;
         } else {
           // No old name. Treat it as a creation
+          logline << "(unpaired) " << kind << "." << endl;
           messages.created(move(path), kind);
         }
         break;
       default:
+        logline << " with unexpected action " << info->Action << "." << endl;
+
         ostringstream out;
         out << "Unexpected action " << info->Action << " reported by ReadDirectoryChangesW for " << path;
         return error_result(out.str());

--- a/test/events/kind-change.test.js
+++ b/test/events/kind-change.test.js
@@ -135,7 +135,7 @@ const {EventMatcher} = require('../matcher');
       await fs.mkdir(reusedPath)
 
       await until('delete and create events arrive', matcher.allEvents(
-        {action: 'deleted', kind: 'file', path: reusedPath},
+        {action: 'deleted', path: reusedPath},
         {action: 'created', kind: 'directory', path: reusedPath}
       ))
     })


### PR DESCRIPTION
Associate renames that are split across event batches on Windows by storing the old path in the subscription.

Fixes #84, at least partially.