### PR TITLE
Skip directory modification events on Windows

### DIFF
--- a/src/worker/windows/windows_worker_platform.cpp
+++ b/src/worker/windows/windows_worker_platform.cpp
@@ -338,8 +338,10 @@ private:
         messages.created(move(path), kind);
         break;
       case FILE_ACTION_MODIFIED:
-        logline << "FILE_ACTION_MODIFIED " << kind << "." << endl;
-        messages.modified(move(path), kind);
+        if (kind != KIND_DIRECTORY) {
+          logline << "FILE_ACTION_MODIFIED " << kind << "." << endl;
+          messages.modified(move(path), kind);
+        }
         break;
       case FILE_ACTION_REMOVED:
         logline << "FILE_ACTION_REMOVED " << kind << "." << endl;


### PR DESCRIPTION
Windows reports `FILE_ACTION_MODIFIED` for directories for a wide variety of actions, including things like modification of a containing file (which technically changes the last-access timestamp on the directory). These aren't useful, so let's just skip them.