### PR TITLE
Consistently report long path names on Windows

### DIFF
--- a/src/helper/windows/helper.cpp
+++ b/src/helper/windows/helper.cpp
@@ -75,7 +75,8 @@ Result<wstring> to_long_path_try(const wstring &short_path, size_t bufsize, bool
 
   if (longpath_length == 0) {
     DWORD longpath_err = GetLastError();
-    if (longpath_err != ERROR_FILE_NOT_FOUND && longpath_err != ERROR_PATH_NOT_FOUND && longpath_err != ERROR_ACCESS_DENIED) {
+    if (longpath_err != ERROR_FILE_NOT_FOUND && longpath_err != ERROR_PATH_NOT_FOUND
+      && longpath_err != ERROR_ACCESS_DENIED) {
       return windows_error_result<wstring>("Unable to convert to long path", longpath_err);
     }
     return ok_result(wstring(short_path));

--- a/src/helper/windows/helper.cpp
+++ b/src/helper/windows/helper.cpp
@@ -67,3 +67,33 @@ Result<wstring> to_wchar(const string &in)
 
   return ok_result(wstring(payload.get(), wlen - 1));
 }
+
+Result<wstring> to_long_path_try(const wstring &short_path, size_t bufsize, bool retry)
+{
+  unique_ptr<wchar_t[]> longpath_data(new wchar_t[bufsize]);
+  DWORD longpath_length = GetLongPathNameW(short_path.c_str(), longpath_data.get(), bufsize);
+
+  if (longpath_length == 0) {
+    DWORD longpath_err = GetLastError();
+    if (longpath_err != ERROR_FILE_NOT_FOUND && longpath_err != ERROR_PATH_NOT_FOUND && longpath_err != ERROR_ACCESS_DENIED) {
+      return windows_error_result<wstring>("Unable to convert to long path", longpath_err);
+    }
+    return ok_result(wstring(short_path));
+  }
+
+  if (longpath_length > bufsize) {
+    longpath_data.reset(nullptr);
+    if (retry) {
+      return to_long_path_try(short_path, longpath_length, false);
+    }
+
+    return ok_result(wstring(short_path));
+  }
+
+  return ok_result(wstring(longpath_data.get(), longpath_length));
+}
+
+Result<wstring> to_long_path(const wstring &short_path)
+{
+  return to_long_path_try(short_path, short_path.size() + 1, true);
+}

--- a/src/helper/windows/helper.h
+++ b/src/helper/windows/helper.h
@@ -13,6 +13,9 @@ Result<std::string> to_utf8(const std::wstring &in);
 // Convert a utf8 string to a wide-character string.
 Result<std::wstring> to_wchar(const std::string &in);
 
+// Convert an 8.3 short path to a long path.
+Result<std::wstring> to_long_path(const std::wstring &short_path);
+
 template <class V = void *>
 Result<V> windows_error_result(const std::string &prefix)
 {

--- a/src/worker/recent_file_cache.cpp
+++ b/src/worker/recent_file_cache.cpp
@@ -256,7 +256,6 @@ void RecentFileCache::update_for_rename(const string &from_dir_path, const strin
 
   for (auto &rename : renames) {
     shared_ptr<PresentEntry> p = by_path[rename.first];
-    by_path.erase(rename.first);
     by_path.emplace(rename.second, p);
   }
 }

--- a/src/worker/recent_file_cache.cpp
+++ b/src/worker/recent_file_cache.cpp
@@ -69,9 +69,9 @@ bool StatResult::could_be_rename_of(const StatResult &other) const
   return !kinds_are_different(entry_kind, other.entry_kind);
 }
 
-bool StatResult::update_for_rename(const std::string &from_dir_path, const std::string &to_dir_path)
+bool StatResult::update_for_rename(const string &from_dir_path, const string &to_dir_path)
 {
-  if (path.size() > from_dir_path.size() && path.rfind(from_dir_path, 0) == 0) {
+  if (path.rfind(from_dir_path, 0) == 0) {
     path = to_dir_path + path.substr(from_dir_path.size());
     return true;
   }

--- a/src/worker/windows/windows_worker_platform.cpp
+++ b/src/worker/windows/windows_worker_platform.cpp
@@ -309,7 +309,10 @@ private:
   {
     ChannelID channel = sub->get_channel();
     wstring relpathw{info->FileName, info->FileNameLength / sizeof(WCHAR)};
-    wstring pathw = sub->make_absolute(move(relpathw));
+    wstring shortpathw = sub->make_absolute(move(relpathw));
+    Result<wstring> longpathr = to_long_path(shortpathw);
+    if (longpathr.is_error()) return longpathr.propagate_as_void();
+    wstring &pathw = longpathr.get_value();
 
     Result<string> u8r = to_utf8(pathw);
     if (u8r.is_error()) {

--- a/test/events/rapid.test.js
+++ b/test/events/rapid.test.js
@@ -62,7 +62,7 @@ const {EventMatcher} = require('../matcher');
           ))
         } else {
           await until('creation and rename events arrive', matcher.orderedEvents(
-            {action: 'created', kind: 'file', path: originalPath},
+            {action: 'created', path: originalPath},
             {action: 'renamed', kind: 'file', oldPath: originalPath, path: finalPath}
           ))
         }
@@ -111,9 +111,9 @@ const {EventMatcher} = require('../matcher');
           ))
         } else {
           await until('creation, rename, and deletion events arrive', matcher.allEvents(
-            {action: 'created', kind: 'file', path: originalPath},
-            {action: 'renamed', kind: 'file', oldPath: originalPath, path: finalPath},
-            {action: 'deleted', kind: 'file', path: finalPath}
+            {action: 'created', path: originalPath},
+            {action: 'renamed', oldPath: originalPath, path: finalPath},
+            {action: 'deleted', path: finalPath}
           ))
         }
       })

--- a/test/events/rapid.test.js
+++ b/test/events/rapid.test.js
@@ -40,8 +40,8 @@ const {EventMatcher} = require('../matcher');
 
         await until('all events arrive', matcher.orderedEvents(
           {action: 'deleted', kind: 'file', path: deletedPath},
-          {action: 'created', kind: 'file', path: recreatedPath},
-          {action: 'deleted', kind: 'file', path: recreatedPath},
+          {action: 'created', path: recreatedPath},
+          {action: 'deleted', path: recreatedPath},
           {action: 'created', kind: 'file', path: recreatedPath},
           {action: 'created', kind: 'file', path: createdPath}
         ))


### PR DESCRIPTION
Convert all path names to long path names whenever possible.

Fixes #85.