### PR TITLE
Drop the buffer size to 128K

### DIFF
--- a/src/worker/windows/subscription.cpp
+++ b/src/worker/windows/subscription.cpp
@@ -16,7 +16,7 @@ using std::string;
 using std::wostringstream;
 using std::wstring;
 
-const DWORD DEFAULT_BUFFER_SIZE = 1024 * 1024;
+const DWORD DEFAULT_BUFFER_SIZE = 128 * 1024;
 const DWORD NETWORK_BUFFER_SIZE = 64 * 1024;
 
 Subscription::Subscription(ChannelID channel,


### PR DESCRIPTION
1MB is overkill for the buffer size.  Batch processing is pretty quick because the worker thread just stats and enqueues all of the events.

Fixes #69.