### PR TITLE
Watch parent directories on Windows

### DIFF
--- a/lib/path-watcher-manager.js
+++ b/lib/path-watcher-manager.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const {PathWatcher} = require('./path-watcher')
 const {NativeWatcher} = require('./native-watcher')
 const {NativeWatcherRegistry} = require('./native-watcher-registry')
@@ -41,6 +42,41 @@ class PathWatcherManager {
   createWatcher (rootPath, options, eventCallback) {
     const watcher = new PathWatcher(this.nativeRegistry, rootPath, options)
     watcher.onDidChange(eventCallback)
+
+    if (process.platform === 'win32' && !options.poll) {
+      watcher.getNormalizedPathPromise().then(normalizedPath => {
+        let previousPath = normalizedPath
+        let currentPath = path.resolve(normalizedPath, '..')
+        while (true) {
+          const parentWatcher = new PathWatcher(this.nativeRegistry, currentPath, {recursive: false})
+          parentWatcher.onDidChange((function (childPath) {
+            return events => {
+              for (const event of events) {
+                if (event.path !== childPath && event.oldPath !== childPath) continue
+                if (event.action !== 'deleted' && event.action !== 'renamed') continue
+
+                parentWatcher.dispose()
+                eventCallback([{
+                  action: 'deleted',
+                  kind: 'directory',
+                  path: normalizedPath
+                }])
+                watcher.dispose()
+              }
+            }
+          })(previousPath))
+
+          let nextPath = path.resolve(currentPath, '..')
+          if (nextPath !== currentPath) {
+            previousPath = currentPath
+            currentPath = nextPath
+          } else {
+            break
+          }
+        }
+      }, () => {})
+    }
+
     return watcher
   }
 


### PR DESCRIPTION
When a directory is watched on Windows, implicitly create non-recursive watchers the whole way up the directory tree to the drive root. When any directory along the way is removed or renamed, emit a synthetic `{ "action": "removed", "kind": "directory", "path": "/root" }` event for the watch root and uninstall it.