### PR TITLE
Restore missing closedir() call

### DIFF
--- a/src/worker/linux/watch_registry.cpp
+++ b/src/worker/linux/watch_registry.cpp
@@ -150,6 +150,7 @@ Result<> WatchRegistry::add(ChannelID channel_id, const string &root, bool recur
       if (errno != 0) {
         return errno_result("Unable to iterate entries of directory " + root);
       }
+      closedir(dir);
     }
   }
 


### PR DESCRIPTION
If you never close the directory handles that you open, it turns out that you start getting EMFILE errors.

:stars: 