### PR TITLE
Track parent path renames on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:debug": "node --harmony script/helper/gen-compilation-db.js rebuild --debug",
     "test": "mocha --require test/global.js --require mocha-stress --recursive --harmony",
     "test:lldb": "lldb -- node --harmony ./node_modules/.bin/_mocha --require test/global.js --require mocha-stress --recursive",
+    "test:gdb": "gdb --args node --harmony ./node_modules/.bin/_mocha --require test/global.js --require mocha-stress --recursive",
     "ci:appveyor": "npm run test -- --fgrep ^windows --invert --reporter mocha-appveyor-reporter --reporter-options appveyorBatchSize=5 --timeout 30000",
     "ci:circle": "npm run test -- --fgrep '^mac' --invert --reporter mocha-junit-reporter --reporter-options mochaFile=${CIRCLE_TEST_REPORTS}/mocha/test-results.xml",
     "ci:travis": "npm run test -- --fgrep '^linux' --invert --reporter list",

--- a/src/worker/linux/linux_worker_platform.cpp
+++ b/src/worker/linux/linux_worker_platform.cpp
@@ -64,12 +64,9 @@ public:
 
       if ((to_poll[1].revents & (POLLIN | POLLERR)) != 0u) {
         MessageBuffer messages;
-        SideEffect side;
 
-        Result<> cr = registry.consume(messages, jar, side);
+        Result<> cr = registry.consume(messages, jar);
         if (cr.is_error()) LOGGER << cr << endl;
-
-        side.enact_in(&registry, messages);
 
         if (!messages.empty()) {
           Result<> er = emit_all(messages.begin(), messages.end());

--- a/src/worker/linux/side_effect.cpp
+++ b/src/worker/linux/side_effect.cpp
@@ -1,3 +1,4 @@
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -9,6 +10,7 @@
 #include "watch_registry.h"
 
 using std::move;
+using std::shared_ptr;
 using std::string;
 using std::vector;
 
@@ -17,11 +19,11 @@ void SideEffect::track_subdirectory(string subdir, ChannelID channel_id)
   subdirectories.emplace_back(move(subdir), channel_id);
 }
 
-void SideEffect::enact_in(WatchRegistry *registry, MessageBuffer &messages)
+void SideEffect::enact_in(const shared_ptr<WatchedDirectory> &parent, WatchRegistry *registry, MessageBuffer &messages)
 {
   for (Subdirectory &subdir : subdirectories) {
     vector<string> poll_roots;
-    Result<> r = registry->add(subdir.channel_id, subdir.path, true, poll_roots);
+    Result<> r = registry->add(subdir.channel_id, parent, subdir.basename, true, poll_roots);
     if (r.is_error()) messages.error(subdir.channel_id, string(r.get_error()), false);
 
     for (string &poll_root : poll_roots) {

--- a/src/worker/linux/watch_registry.cpp
+++ b/src/worker/linux/watch_registry.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <string>
 #include <sys/inotify.h>
 #include <sys/types.h>
@@ -22,11 +23,16 @@
 
 using std::endl;
 using std::ostream;
+using std::ostringstream;
 using std::set;
 using std::shared_ptr;
 using std::string;
 using std::unordered_multimap;
 using std::vector;
+
+using WatchedDirectoryPtr = shared_ptr<WatchedDirectory>;
+using WDMap = unordered_multimap<int, WatchedDirectoryPtr>;
+using WDIter = WDMap::iterator;
 
 static ostream &operator<<(ostream &out, const inotify_event *event)
 {
@@ -75,46 +81,69 @@ WatchRegistry::~WatchRegistry()
   }
 }
 
-Result<> WatchRegistry::add(ChannelID channel_id, const string &root, bool recursive, vector<string> &poll)
+Result<> WatchRegistry::add(ChannelID channel_id,
+  const shared_ptr<WatchedDirectory> &parent,
+  const string &name,
+  bool recursive,
+  vector<string> &poll)
 {
   uint32_t mask = IN_ATTRIB | IN_CREATE | IN_DELETE | IN_DELETE_SELF | IN_MODIFY | IN_MOVE_SELF | IN_MOVED_FROM
     | IN_MOVED_TO | IN_DONT_FOLLOW | IN_EXCL_UNLINK | IN_ONLYDIR;
 
-  ostream &logline = LOGGER << "Watching path [" << root << "]";
+  ostringstream absolute_builder;
+  if (parent) {
+    absolute_builder << parent->get_absolute_path() << "/";
+  }
+  absolute_builder << name;
+  string absolute = absolute_builder.str();
+
+  ostream &logline = LOGGER << "Watching path [" << absolute << "]";
   if (!recursive) logline << " (non-recursively)";
   logline << "." << endl;
 
-  int wd = inotify_add_watch(inotify_fd, root.c_str(), mask);
+  int wd = inotify_add_watch(inotify_fd, absolute.c_str(), mask);
   if (wd == -1) {
     int watch_errno = errno;
 
     if (watch_errno == ENOENT || watch_errno == EACCES) {
-      LOGGER << "Directory " << root << " is no longer accessible. Ignoring." << endl;
+      LOGGER << "Directory " << absolute << " is no longer accessible. Ignoring." << endl;
       return ok_result();
     }
 
     if (watch_errno == ENOSPC) {
-      LOGGER << "Falling back to polling for directory " << root << "." << endl;
-      poll.push_back(root);
+      LOGGER << "Falling back to polling for directory " << absolute << "." << endl;
+      poll.push_back(absolute);
       return ok_result();
     }
 
     return errno_result("Unable to watch directory", watch_errno);
   }
 
-  LOGGER << "Assigned watch descriptor " << wd << " at [" << root << "] on channel " << channel_id << "." << endl;
+  LOGGER << "Assigned watch descriptor " << wd << " at [" << absolute << "] on channel " << channel_id << "." << endl;
 
-  shared_ptr<WatchedDirectory> watched_dir(new WatchedDirectory(wd, channel_id, string(root), recursive));
+  auto range = by_wd.equal_range(wd);
+  bool updated = false;
+  for (auto existing = range.first; existing != range.second; ++existing) {
+    shared_ptr<WatchedDirectory> &other = existing->second;
+    if (other->get_channel_id() == channel_id) {
+      assert(parent != nullptr);
+      updated = true;
+      other->was_renamed(parent, name);
+    }
+  }
+  if (updated) return ok_result();
 
-  by_wd.insert({wd, watched_dir});
-  by_channel.insert({channel_id, watched_dir});
+  shared_ptr<WatchedDirectory> watched_dir(new WatchedDirectory(wd, channel_id, parent, string(name), recursive));
+
+  by_wd.emplace(wd, watched_dir);
+  by_channel.emplace(channel_id, watched_dir);
 
   if (recursive) {
-    DIR *dir = opendir(root.c_str());
+    DIR *dir = opendir(absolute.c_str());
     if (dir == nullptr) {
       int open_errno = errno;
       if (open_errno != EACCES && open_errno != ENOENT && open_errno != ENOTDIR) {
-        return errno_result("Unable to recurse into directory " + root, open_errno);
+        return errno_result("Unable to recurse into directory " + absolute, open_errno);
       }
     } else {
       errno = 0;
@@ -126,21 +155,18 @@ Result<> WatchRegistry::add(ChannelID channel_id, const string &root, bool recur
           entry = readdir(dir);
           continue;
         }
-        string subdir(root);
-        subdir += "/";
-        subdir += basename;
 
 #ifdef _DIRENT_HAVE_D_TYPE
         if (entry->d_type == DT_DIR || entry->d_type == DT_UNKNOWN) {
-          Result<> add_r = add(channel_id, subdir, recursive, poll);
+          Result<> add_r = add(channel_id, watched_dir, basename, recursive, poll);
           if (add_r.is_error()) {
-            LOGGER << "Unable to recurse into " << subdir << ": " << add_r << "." << endl;
+            LOGGER << "Unable to recurse into " << absolute << "/" << basename << ": " << add_r << "." << endl;
           }
         }
 #else
-        Result<> add_r = add(channel_id, subdir, recursive, poll);
+        Result<> add_r = add(channel_id, watched_dir, basename, recursive, poll);
         if (add_r.is_error()) {
-          LOGGER << "Unable to recurse into " << subdir << ": " << add_r << "." << endl;
+          LOGGER << "Unable to recurse into " << absolute << "/" << basename << ": " << add_r << "." << endl;
         }
 #endif
 
@@ -148,7 +174,7 @@ Result<> WatchRegistry::add(ChannelID channel_id, const string &root, bool recur
         entry = readdir(dir);
       }
       if (errno != 0) {
-        return errno_result("Unable to iterate entries of directory " + root);
+        return errno_result("Unable to iterate entries of directory " + absolute);
       }
     }
   }
@@ -158,10 +184,6 @@ Result<> WatchRegistry::add(ChannelID channel_id, const string &root, bool recur
 
 Result<> WatchRegistry::remove(ChannelID channel_id)
 {
-  using WatchedDirectoryPtr = shared_ptr<WatchedDirectory>;
-  using WDMap = unordered_multimap<int, WatchedDirectoryPtr>;
-  using WDIter = WDMap::iterator;
-
   auto its = by_channel.equal_range(channel_id);
   set<int> wds;
   for (auto it = its.first; it != its.second; ++it) {
@@ -196,7 +218,7 @@ Result<> WatchRegistry::remove(ChannelID channel_id)
   return ok_result();
 }
 
-Result<> WatchRegistry::consume(MessageBuffer &messages, CookieJar &jar, SideEffect &side)
+Result<> WatchRegistry::consume(MessageBuffer &messages, CookieJar &jar)
 {
   const size_t BUFSIZE = 2048 * sizeof(inotify_event);
   char buf[BUFSIZE] __attribute__((aligned(__alignof__(struct inotify_event))));
@@ -243,12 +265,12 @@ Result<> WatchRegistry::consume(MessageBuffer &messages, CookieJar &jar, SideEff
       }
 
       for (auto it = its.first; it != its.second; ++it) {
+        SideEffect side;
         shared_ptr<WatchedDirectory> watched_directory = it->second;
 
         Result<> r = watched_directory->accept_event(messages, jar, side, *event);
-        if (r.is_error()) {
-          LOGGER << "Unable to process event: " << r << "." << endl;
-        }
+        if (r.is_error()) LOGGER << "Unable to process event: " << r << "." << endl;
+        side.enact_in(watched_directory, this, messages);
       }
     }
   }

--- a/src/worker/linux/watch_registry.h
+++ b/src/worker/linux/watch_registry.h
@@ -29,15 +29,29 @@ public:
   // will be accumulated into the `poll` vector.
   //
   // `root` must name a directory if `recursive` is `true`.
-  Result<> add(ChannelID channel_id, const std::string &root, bool recursive, std::vector<std::string> &poll);
+  Result<> add(ChannelID channel_id, const std::string &root, bool recursive, std::vector<std::string> &poll)
+  {
+    return add(channel_id, nullptr, root, recursive, poll);
+  }
+
+  // Begin watching path beneath an existing WatchedDirectory. If `recursive` is `true`, recursively watch all
+  // subdirectories as well. If inotify watch descriptors are exhausted before the entire directory tree can be watched,
+  // the unsuccessfully watched roots will be accumulated into the `poll` vector.
+  //
+  // `root` must name a directory if `recursive` is `true`.
+  Result<> add(ChannelID channel_id,
+    const std::shared_ptr<WatchedDirectory> &parent,
+    const std::string &name,
+    bool recursive,
+    std::vector<std::string> &poll);
 
   // Uninstall inotify watchers used to deliver events on a specified channel.
   Result<> remove(ChannelID channel_id);
 
   // Interpret all inotify events created since the previous call to consume(), until the
   // read() call would block. Buffer messages corresponding to each inotify event. Use the
-  // CookieJar to match pairs of rename events and the SideEffect to enqueue side effects.
-  Result<> consume(MessageBuffer &messages, CookieJar &jar, SideEffect &side);
+  // CookieJar to match pairs of rename events across event batches.
+  Result<> consume(MessageBuffer &messages, CookieJar &jar);
 
   // Return the file descriptor that should be polled to wake up when inotify events are
   // available.

--- a/test/events/parent-rename.test.js
+++ b/test/events/parent-rename.test.js
@@ -30,7 +30,7 @@ describe('when a parent directory is renamed', function () {
     await fixture.after(this.currentTest)
   })
 
-  it('tracks the file rename across event batches ^linux', async function () {
+  it('tracks the file rename across event batches', async function () {
     const changedFile = fixture.watchPath('parent-1', 'file-1.txt')
 
     await fs.rename(originalParentDir, finalParentDir)

--- a/test/events/parent-rename.test.js
+++ b/test/events/parent-rename.test.js
@@ -45,7 +45,7 @@ describe('when a parent directory is renamed', function () {
     ))
   })
 
-  it('tracks the file rename within the same event batch ^linux', async function () {
+  it('tracks the file rename within the same event batch', async function () {
     const changedFile = fixture.watchPath('parent-1', 'file-1.txt')
 
     await fs.rename(originalParentDir, finalParentDir)
@@ -57,7 +57,7 @@ describe('when a parent directory is renamed', function () {
     ))
   })
 
-  it('tracks the file rename when the directory is renamed first ^linux', async function () {
+  it('tracks the file rename when the file is renamed first', async function () {
     const changedFile = fixture.watchPath('parent-0', 'file-1.txt')
 
     await fs.rename(originalFile, changedFile)


### PR DESCRIPTION
Get the test cases introduced by #90 and #92 passing on Linux. These will ensure that we report absolute paths correctly when a parent directory has been renamed.