### PR TITLE
Rename or deletion of watch root on Linux

### DIFF
--- a/src/worker/linux/side_effect.cpp
+++ b/src/worker/linux/side_effect.cpp
@@ -21,7 +21,16 @@ void SideEffect::track_subdirectory(string subdir, ChannelID channel_id)
 
 void SideEffect::enact_in(const shared_ptr<WatchedDirectory> &parent, WatchRegistry *registry, MessageBuffer &messages)
 {
+  for (ChannelID channel_id : removed_roots) {
+    Result<> r = registry->remove(channel_id);
+    if (r.is_error()) messages.error(channel_id, string(r.get_error()), false);
+  }
+
   for (Subdirectory &subdir : subdirectories) {
+    if (removed_roots.find(subdir.channel_id) != removed_roots.end()) {
+      continue;
+    }
+
     vector<string> poll_roots;
     Result<> r = registry->add(subdir.channel_id, parent, subdir.basename, true, poll_roots);
     if (r.is_error()) messages.error(subdir.channel_id, string(r.get_error()), false);

--- a/src/worker/linux/side_effect.h
+++ b/src/worker/linux/side_effect.h
@@ -2,6 +2,7 @@
 #define SIDE_EFFECT_H
 
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -26,6 +27,9 @@ public:
 
   // Recursively watch a newly created subdirectory.
   void track_subdirectory(std::string subdir, ChannelID channel_id);
+
+  // Unsubscribe from a channel after this event has been handled.
+  void remove_channel(ChannelID channel_id) { removed_roots.insert(channel_id); }
 
   // Perform all enqueued actions.
   void enact_in(const std::shared_ptr<WatchedDirectory> &parent, WatchRegistry *registry, MessageBuffer &messages);
@@ -59,6 +63,8 @@ private:
   };
 
   std::vector<Subdirectory> subdirectories;
+
+  std::set<ChannelID> removed_roots;
 };
 
 #endif

--- a/src/worker/linux/watch_registry.cpp
+++ b/src/worker/linux/watch_registry.cpp
@@ -264,10 +264,13 @@ Result<> WatchRegistry::consume(MessageBuffer &messages, CookieJar &jar)
         continue;
       }
 
+      vector<shared_ptr<WatchedDirectory>> watched_directories;
       for (auto it = its.first; it != its.second; ++it) {
-        SideEffect side;
-        shared_ptr<WatchedDirectory> watched_directory = it->second;
+        watched_directories.emplace_back(it->second);
+      }
 
+      for (shared_ptr<WatchedDirectory> &watched_directory : watched_directories) {
+        SideEffect side;
         Result<> r = watched_directory->accept_event(messages, jar, side, *event);
         if (r.is_error()) LOGGER << "Unable to process event: " << r << "." << endl;
         side.enact_in(watched_directory, this, messages);

--- a/src/worker/linux/watched_directory.cpp
+++ b/src/worker/linux/watched_directory.cpp
@@ -61,12 +61,19 @@ Result<> WatchedDirectory::accept_event(MessageBuffer &buffer,
   }
 
   if ((event.mask & (IN_DELETE_SELF | IN_UNMOUNT)) != 0u) {
-    buffer.deleted(channel_id, move(path), kind);
+    if (is_root()) {
+      side.remove_channel(channel_id);
+      buffer.deleted(channel_id, get_absolute_path(), KIND_DIRECTORY);
+    }
     return ok_result();
   }
 
   if ((event.mask & IN_MOVE_SELF) == IN_MOVE_SELF) {
     // directory itself was renamed
+    if (is_root()) {
+      side.remove_channel(channel_id);
+      buffer.deleted(channel_id, get_absolute_path(), KIND_DIRECTORY);
+    }
     return ok_result();
   }
 

--- a/src/worker/linux/watched_directory.h
+++ b/src/worker/linux/watched_directory.h
@@ -42,6 +42,9 @@ public:
   // Access the watch descriptor that corresponds to this directory.
   int get_descriptor() { return wd; }
 
+  // Return true if this directory is the root of a recursively watched subtree.
+  bool is_root() { return parent == nullptr; }
+
   // Return the full absolute path to this directory.
   std::string get_absolute_path();
 

--- a/test/events/root-rename.test.js
+++ b/test/events/root-rename.test.js
@@ -20,7 +20,7 @@ const {EventMatcher} = require('../matcher');
       await fixture.after(this.currentTest)
     })
 
-    it('emits a deletion event for the root move itself ^windows ^linux', async function () {
+    it('emits a deletion event for the root move itself ^windows', async function () {
       const oldRoot = fixture.watchPath()
       const newRoot = fixture.fixturePath('new-root')
 
@@ -31,7 +31,7 @@ const {EventMatcher} = require('../matcher');
       ))
     })
 
-    it('does not emit events within the new root ^windows ^linux', async function () {
+    it('does not emit events within the new root ^windows', async function () {
       const oldRoot = fixture.watchPath()
       const oldFile = fixture.watchPath('some-file.txt')
       const newRoot = fixture.fixturePath('new-root')


### PR DESCRIPTION
inotify watch descriptors actually follow directories that are renamed, but unless you're watching the parent directory as well, you have no way to know where they're renamed _to_ (and therefore construct absolute paths for events received within them).

Fortunately, inotify has dedicated event flags (`IN_MOVE_SELF` and `IN_DELETE_SELF`) that signal operations performed on the watched directory itself. This makes it pretty easy to synthesize a deletion event and clean up the now-defunct descriptors.