### PR TITLE
Include a test case that exercises utf8 paths

### DIFF
--- a/src/helper/windows/helper.cpp
+++ b/src/helper/windows/helper.cpp
@@ -44,8 +44,8 @@ Result<wstring> to_wchar(const string &in)
 {
   size_t wlen = MultiByteToWideChar(CP_UTF8,  // code page
     0,  // flags
-    in.c_str(),  // source string data
-    -1,  // source string length (null-terminated)
+    in.data(),  // source string data
+    in.size(),  // source string length (null-terminated)
     0,  // output buffer
     0  // output buffer size
   );
@@ -56,8 +56,8 @@ Result<wstring> to_wchar(const string &in)
   unique_ptr<WCHAR[]> payload(new WCHAR[wlen]);
   size_t conv_success = MultiByteToWideChar(CP_UTF8,  // code page
     0,  // flags,
-    in.c_str(),  // source string data
-    -1,  // source string length (null-terminated)
+    in.data(),  // source string data
+    in.size(),  // source string length (null-terminated)
     payload.get(),  // output buffer
     wlen  // output buffer size (in bytes)
   );
@@ -65,7 +65,7 @@ Result<wstring> to_wchar(const string &in)
     return windows_error_result<wstring>("Unable to convert string to wide string");
   }
 
-  return ok_result(wstring(payload.get(), wlen - 1));
+  return ok_result(wstring(payload.get(), wlen));
 }
 
 Result<wstring> to_long_path_try(const wstring &short_path, size_t bufsize, bool retry)

--- a/test/events/unicode-paths.test.js
+++ b/test/events/unicode-paths.test.js
@@ -12,16 +12,20 @@ describe('paths with extended utf8 characters', function () {
     await fixture.log()
   })
 
+  afterEach(async function () {
+    await fixture.after(this.currentTest)
+  })
+
   it('creates watches and reports event paths', async function () {
     // Thanks, http://www.i18nguy.com/unicode/supplementary-test.html
     // I sure hope these don't mean anything really obscene!
-    const rootDir = fixture.watchPath('𠜎 𠜱 𠝹 𠱓 𠱸 ')
-    const fileName = fixture.watchPath('𠜎 𠜱 𠝹 𠱓 𠱸 ', '𢵧 𢺳 𣲷 𤓓')
+    const rootDir = fixture.watchPath('𠜎')
+    const fileName = fixture.watchPath('𠜎', '𤓓')
 
-    await fs.mkdir(rootDir)
+    await fs.mkdirs(rootDir)
 
     const matcher = new EventMatcher(fixture)
-    await matcher.watch(['𠜎 𠜱 𠝹 𠱓 𠱸 '], {})
+    await matcher.watch(['𠜎'], {})
 
     await fs.writeFile(fileName, 'wat\n')
 

--- a/test/events/unicode-paths.test.js
+++ b/test/events/unicode-paths.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs-extra')
+
+const {Fixture} = require('../helper')
+const {EventMatcher} = require('../matcher')
+
+describe('paths with extended utf8 characters', function () {
+  let fixture
+
+  beforeEach(async function () {
+    fixture = new Fixture()
+    await fixture.before()
+    await fixture.log()
+  })
+
+  it('creates watches and reports event paths', async function () {
+    // Thanks, http://www.i18nguy.com/unicode/supplementary-test.html
+    // I sure hope these don't mean anything really obscene!
+    const rootDir = fixture.watchPath('𠜎 𠜱 𠝹 𠱓 𠱸 ')
+    const fileName = fixture.watchPath('𠜎 𠜱 𠝹 𠱓 𠱸 ', '𢵧 𢺳 𣲷 𤓓')
+
+    await fs.mkdir(rootDir)
+
+    const matcher = new EventMatcher(fixture)
+    await matcher.watch(['𠜎 𠜱 𠝹 𠱓 𠱸 '], {})
+
+    await fs.writeFile(fileName, 'wat\n')
+
+    await until('creation event arrives', matcher.allEvents(
+      {action: 'created', kind: 'file', path: fileName}
+    ))
+  })
+})


### PR DESCRIPTION
Test a watch root and event path that includes [four-byte utf8 characters](http://www.i18nguy.com/unicode/supplementary-test.html).

Fixes #12.