### PR TITLE
Accept zero-size event batches from ReadDirectoryChangeW

### DIFF
--- a/src/worker/windows/windows_worker_platform.cpp
+++ b/src/worker/windows/windows_worker_platform.cpp
@@ -217,6 +217,11 @@ public:
       return emit_fatal_error(sub, windows_error_result<>("Completion callback error", error_code));
     }
 
+    if (num_bytes == 0) {
+      LOGGER << "Empty event batch received." << endl;
+      return reschedule(sub);
+    }
+
     // Schedule the next completion callback.
     BYTE *base = sub->get_written(num_bytes);
     Result<> next = reschedule(sub);


### PR DESCRIPTION
When you disconnect a Samba share, a watcher on a directory within it will report an empty event batch.

Fixes #118.