### PR TITLE
Initialize threads before the first handle_commands() call

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -148,6 +148,9 @@ void Thread::start()
     in.enqueue_all(starter_messages.begin(), starter_messages.end());
   }
 
+  // Initialize any state necessary to call command handler methods.
+  Result<> ir = init();
+
   // Handle any commands that were enqueued while the thread was starting.
   Result<size_t> cr = handle_commands();
   if (cr.is_error()) {

--- a/src/thread.h
+++ b/src/thread.h
@@ -68,13 +68,17 @@ public:
 
 protected:
   // Invoked on the newly created thread. Responsible for performing thread startup, consuming any `ThreadStart`
-  // initialization and transitioning to the `RUNNING` phase. Calls `Thread::body()` to perform subclass-defined
-  // work, which subclasses should override with their main message loop. Transitions the thread to the `STOPPED`
-  // phase just before existing.
+  // initialization and transitioning to the `RUNNING` phase. Calls `Thread::init()` to perform any one-time setup,
+  // handles any messages that were enqueued while the thread was starting, then calls `Thread::body()` to perform
+  // subclass-defined work, which subclasses should override with their main message loop. Transitions the thread to the
+  // `STOPPED` phase just before existing.
   void start();
 
-  // Override to perform the primary message loop of a subclass. Call `Thread::mark_stopping()` and to stop the thread
-  // in an orderly fashion.
+  // Override to perform thread state initialization that must occur before any messages are handled.
+  virtual Result<> init() { return ok_result(); }
+
+  // Override to perform the primary message loop of a subclass. Call `Thread::mark_stopping()` and return to stop the
+  // thread in an orderly fashion.
   virtual Result<> body() { return ok_result(); }
 
   // Override to hint that `Thread::body()` should wake from sleep and call `Thread::handle_commands()` to accept

--- a/src/worker/macos/macos_worker_platform.cpp
+++ b/src/worker/macos/macos_worker_platform.cpp
@@ -63,7 +63,7 @@ public:
     return ok_result();
   }
 
-  Result<> listen() override
+  Result<> init() override
   {
     run_loop.set_from_get(CFRunLoopGetCurrent());
 
@@ -82,6 +82,11 @@ public:
     command_source.set_from_create(CFRunLoopSourceCreate(kCFAllocatorDefault, 1, &command_context));
     CFRunLoopAddSource(run_loop.get(), command_source.get(), kCFRunLoopDefaultMode);
 
+    return ok_result();
+  }
+
+  Result<> listen() override
+  {
     CFRunLoopRun();
     return ok_result();
   }

--- a/src/worker/windows/windows_worker_platform.cpp
+++ b/src/worker/windows/windows_worker_platform.cpp
@@ -75,25 +75,28 @@ public:
     return ok_result();
   }
 
-  Result<> listen() override
+  Result<> init() override
   {
-    {
-      Lock lock(thread_handle_mutex);
+    Lock lock(thread_handle_mutex);
 
-      HANDLE pseudo_handle = GetCurrentThread();
-      BOOL success = DuplicateHandle(GetCurrentProcess(),  // Source process
-        pseudo_handle,  // Source handle
-        GetCurrentProcess(),  // Destination process
-        &thread_handle,  // Destination handle
-        0,  // Desired access
-        FALSE,  // Inheritable by new processes
-        DUPLICATE_SAME_ACCESS  // options
-      );
-      if (!success) {
-        return windows_error_result<>("Unable to duplicate thread handle");
-      }
+    HANDLE pseudo_handle = GetCurrentThread();
+    BOOL success = DuplicateHandle(GetCurrentProcess(),  // Source process
+      pseudo_handle,  // Source handle
+      GetCurrentProcess(),  // Destination process
+      &thread_handle,  // Destination handle
+      0,  // Desired access
+      FALSE,  // Inheritable by new processes
+      DUPLICATE_SAME_ACCESS  // options
+    );
+    if (!success) {
+      return windows_error_result<>("Unable to duplicate thread handle");
     }
 
+    return ok_result();
+  }
+
+  Result<> listen() override
+  {
     while (true) {
       SleepEx(INFINITE, true);
     }

--- a/src/worker/worker_platform.h
+++ b/src/worker/worker_platform.h
@@ -20,6 +20,8 @@ public:
 
   virtual Result<> wake() = 0;
 
+  virtual Result<> init() { return ok_result(); }
+
   virtual Result<> listen() = 0;
 
   virtual Result<bool> handle_add_command(CommandID command,

--- a/src/worker/worker_thread.cpp
+++ b/src/worker/worker_thread.cpp
@@ -30,6 +30,11 @@ Result<> WorkerThread::wake()
   return platform->wake();
 }
 
+Result<> WorkerThread::init()
+{
+  return platform->init();
+}
+
 Result<> WorkerThread::body()
 {
   return platform->listen();

--- a/src/worker/worker_thread.h
+++ b/src/worker/worker_thread.h
@@ -26,6 +26,8 @@ public:
 private:
   Result<> wake() override;
 
+  Result<> init() override;
+
   Result<> body() override;
 
   Result<CommandOutcome> handle_add_command(const CommandPayload *payload) override;


### PR DESCRIPTION
If any commands are enqueued for the worker thread before the first call to `MacOSWorkerPlatform::listen()`, some of the state that's necessary for the `handle_xyz_command()` methods hasn't had a chance to be configured yet. Adding an `init()` phase that's guaranteed to be called before the first handle method should help this.

Part of #120.