### PR TITLE
Evict cache entries for expired rename moves

### DIFF
--- a/src/worker/linux/cookie_jar.cpp
+++ b/src/worker/linux/cookie_jar.cpp
@@ -41,7 +41,7 @@ void CookieBatch::moved_from(MessageBuffer &messages,
     // Duplicate IN_MOVED_FROM cookie.
     // Resolve the old one as a deletion.
     Cookie dup(move(existing->second));
-    messages.deleted(dup.get_channel_id(), dup.get_from_path(), dup.get_kind());
+    messages.deleted(dup.get_channel_id(), dup.move_from_path(), dup.get_kind());
     from_paths.erase(existing);
   }
 
@@ -66,7 +66,7 @@ void CookieBatch::flush(MessageBuffer &messages, RecentFileCache &cache)
   for (auto &pair : from_paths) {
     Cookie dup(move(pair.second));
     cache.evict(dup.get_from_path());
-    messages.deleted(dup.get_channel_id(), dup.get_from_path(), dup.get_kind());
+    messages.deleted(dup.get_channel_id(), dup.move_from_path(), dup.get_kind());
   }
   from_paths.clear();
 }
@@ -100,7 +100,7 @@ void CookieJar::moved_to(MessageBuffer &messages,
       if (from) {
         // Multiple IN_MOVED_FROM results.
         // Report deletions for all but the most recent.
-        messages.deleted(from->get_channel_id(), from->get_from_path(), from->get_kind());
+        messages.deleted(from->get_channel_id(), from->move_from_path(), from->get_kind());
       }
 
       from = move(found);
@@ -117,12 +117,12 @@ void CookieJar::moved_to(MessageBuffer &messages,
   if (from->get_channel_id() != channel_id || kinds_are_different(from->get_kind(), kind)) {
     // Existing IN_MOVED_FROM with this cookie does not match.
     // Resolve it as a deletion/creation pair.
-    messages.deleted(from->get_channel_id(), from->get_from_path(), from->get_kind());
+    messages.deleted(from->get_channel_id(), from->move_from_path(), from->get_kind());
     messages.created(channel_id, move(new_path), kind);
     return;
   }
 
-  messages.renamed(channel_id, from->get_from_path(), move(new_path), kind);
+  messages.renamed(channel_id, from->move_from_path(), move(new_path), kind);
 }
 
 void CookieJar::flush_oldest_batch(MessageBuffer &messages, RecentFileCache &cache)

--- a/src/worker/linux/cookie_jar.h
+++ b/src/worker/linux/cookie_jar.h
@@ -10,6 +10,7 @@
 
 #include "../../message.h"
 #include "../../message_buffer.h"
+#include "../recent_file_cache.h"
 
 // Remember a path that was observed in an IN_MOVED_FROM inotify event until its corresponding IN_MOVED_TO event
 // is observed, or until it times out.
@@ -57,8 +58,8 @@ public:
   // exists.
   std::unique_ptr<Cookie> yoink(uint32_t cookie);
 
-  // Age off all Cookies within this batch by buffering them as deletion events.
-  void flush(MessageBuffer &messages);
+  // Age off all Cookies within this batch by buffering them as deletion events. Evict them from the cache.
+  void flush(MessageBuffer &messages, RecentFileCache &cache);
 
   bool empty() const { return from_paths.empty(); }
 
@@ -104,7 +105,7 @@ public:
 
   // Buffer deletion events for any Cookies that have not been matched within `max_batches` CookieBatches. Add a
   // fresh CookieBatch to capture the next cycle of rename events.
-  void flush_oldest_batch(MessageBuffer &messages);
+  void flush_oldest_batch(MessageBuffer &messages, RecentFileCache &cache);
 
   CookieJar(const CookieJar &other) = delete;
   CookieJar(CookieJar &&other) = delete;

--- a/src/worker/linux/cookie_jar.h
+++ b/src/worker/linux/cookie_jar.h
@@ -23,8 +23,11 @@ public:
 
   const ChannelID &get_channel_id() const { return channel_id; }
 
+  // Access the absolute path from this event.
+  const std::string &get_from_path() { return from_path; }
+
   // Take possession of the absolute path from this event.
-  std::string get_from_path() { return std::string(std::move(from_path)); }
+  std::string move_from_path() { return std::string(std::move(from_path)); }
 
   const EntryKind &get_kind() { return kind; }
 
@@ -74,8 +77,8 @@ private:
 
 // Associate IN_MOVED_FROM and IN_MOVED_TO events from inotify received within a configurable number of consecutive
 // notification cycles. The CookieJar contains a fixed number of CookieBatches that contain unmatched IN_MOVED_FROM
-// events collected within a single notification cycle. As more notifications arrive, events that remain unmatched
-// are aged off and emitted as deletion events.
+// events collected within a single notification cycle. As more notifications arrive or read() calls time out, events
+// that remain unmatched are aged off and emitted as deletion events.
 class CookieJar
 {
 public:

--- a/src/worker/linux/watch_registry.cpp
+++ b/src/worker/linux/watch_registry.cpp
@@ -233,7 +233,7 @@ Result<> WatchRegistry::consume(MessageBuffer &messages, CookieJar &jar, RecentF
     result = read(inotify_fd, &buf, BUFSIZE);
 
     if (result <= 0) {
-      jar.flush_oldest_batch(messages);
+      jar.flush_oldest_batch(messages, cache);
 
       t.stop();
       LOGGER << plural(batch_count, "filesystem event batch", "filesystem event batches") << " containing "

--- a/src/worker/macos/macos_worker_platform.cpp
+++ b/src/worker/macos/macos_worker_platform.cpp
@@ -220,7 +220,7 @@ public:
     handler.handle_deferred();
     cache.apply();
 
-    shared_ptr<set<RenameBuffer::Key>> out = rename_buffer.flush_unmatched(message_buffer);
+    shared_ptr<set<RenameBuffer::Key>> out = rename_buffer.flush_unmatched(message_buffer, cache);
     if (!out->empty()) {
       LOGGER << "Scheduling expiration of " << out->size() << " unpaired rename entries on channel " << channel_id
              << "." << endl;
@@ -271,7 +271,7 @@ public:
     MessageBuffer buffer;
     ChannelMessageBuffer message_buffer(buffer, channel_id);
 
-    shared_ptr<set<RenameBuffer::Key>> next = rename_buffer.flush_unmatched(message_buffer, keys);
+    shared_ptr<set<RenameBuffer::Key>> next = rename_buffer.flush_unmatched(message_buffer, cache, keys);
     assert(next->empty());
     keys.reset();
 

--- a/src/worker/macos/rename_buffer.cpp
+++ b/src/worker/macos/rename_buffer.cpp
@@ -156,7 +156,8 @@ bool RenameBuffer::observe_absent(Event &event, BatchHandler & /*batch*/, const 
   return true;
 }
 
-shared_ptr<set<RenameBuffer::Key>> RenameBuffer::flush_unmatched(ChannelMessageBuffer &message_buffer)
+shared_ptr<set<RenameBuffer::Key>> RenameBuffer::flush_unmatched(ChannelMessageBuffer &message_buffer,
+  RecentFileCache &cache)
 {
   shared_ptr<set<Key>> all(new set<Key>);
 
@@ -164,10 +165,11 @@ shared_ptr<set<RenameBuffer::Key>> RenameBuffer::flush_unmatched(ChannelMessageB
     all->insert(it.first);
   }
 
-  return flush_unmatched(message_buffer, all);
+  return flush_unmatched(message_buffer, cache, all);
 }
 
 shared_ptr<set<RenameBuffer::Key>> RenameBuffer::flush_unmatched(ChannelMessageBuffer &message_buffer,
+  RecentFileCache &cache,
   const shared_ptr<set<Key>> &keys)
 {
   shared_ptr<set<Key>> aged(new set<Key>);
@@ -191,6 +193,7 @@ shared_ptr<set<RenameBuffer::Key>> RenameBuffer::flush_unmatched(ChannelMessageB
       message_buffer.created(string(event_path), entry->get_entry_kind());
     } else {
       message_buffer.deleted(string(event_path), entry->get_entry_kind());
+      cache.evict(event_path);
     }
     to_erase.push_back(key);
   }

--- a/src/worker/macos/rename_buffer.h
+++ b/src/worker/macos/rename_buffer.h
@@ -60,11 +60,12 @@ public:
   // event batches.
   //
   // Return the collection of unpaired Keys that were created during this run.
-  std::shared_ptr<std::set<Key>> flush_unmatched(ChannelMessageBuffer &message_buffer);
+  std::shared_ptr<std::set<Key>> flush_unmatched(ChannelMessageBuffer &message_buffer, RecentFileCache &cache);
 
   // Enqueue creation and removal events for buffer entries that map to any of the listed keys. Return the collection
   // of unpaired Keys that were aged, but not processed, during this run.
   std::shared_ptr<std::set<Key>> flush_unmatched(ChannelMessageBuffer &message_buffer,
+    RecentFileCache &cache,
     const std::shared_ptr<std::set<Key>> &keys);
 
   size_t size() { return observed_by_inode.size(); }

--- a/test/events/unpaired-rename.test.js
+++ b/test/events/unpaired-rename.test.js
@@ -57,5 +57,28 @@ const {EventMatcher} = require('../matcher');
         {action: 'deleted', kind: 'file', path: insideFile}
       ))
     })
+
+    it('when a file is renamed out of, then back into, the watch root', async function () {
+      const outsideFile = fixture.fixturePath('file.txt')
+      const insideFile = fixture.watchPath('file.txt')
+
+      await fs.writeFile(insideFile, 'contents')
+
+      await until('the creation event arrives', matcher.allEvents(
+        {action: 'created', kind: 'file', path: insideFile}
+      ))
+      matcher.reset()
+
+      await fs.rename(insideFile, outsideFile)
+      await until('the deletion event arrives', matcher.allEvents(
+        {action: 'deleted', kind: 'file', path: insideFile}
+      ))
+      matcher.reset()
+
+      await fs.rename(outsideFile, insideFile)
+      await until('the re-creation event arrives', matcher.allEvents(
+        {action: 'created', kind: 'file', path: insideFile}
+      ))
+    })
   })
 })

--- a/test/events/unpaired-rename.test.js
+++ b/test/events/unpaired-rename.test.js
@@ -35,24 +35,13 @@ const {EventMatcher} = require('../matcher');
     it('when a file is renamed from inside of the watch root out', async function () {
       const outsideFile = fixture.fixturePath('file.txt')
       const insideFile = fixture.watchPath('file.txt')
-      const flagFile = fixture.watchPath('flag.txt')
 
       await fs.writeFile(insideFile, 'contents')
-
       await until('the creation event arrives', matcher.allEvents(
         {action: 'created', kind: 'file', path: insideFile}
       ))
 
       await fs.rename(insideFile, outsideFile)
-      await fs.writeFile(flagFile, 'flag 1')
-
-      await until('the flag file event arrives', matcher.allEvents(
-        {action: 'created', kind: 'file', path: flagFile}
-      ))
-
-      // Trigger another batch of events on Linux
-      await fs.writeFile(flagFile, 'flag 2')
-
       await until('the deletion event arrives', matcher.allEvents(
         {action: 'deleted', kind: 'file', path: insideFile}
       ))


### PR DESCRIPTION
When synthesizing deletion events for unpaired renames on MacOS, be sure to evict the file from the cache.

Fixes #117.