### PR TITLE
Add a CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,20 @@ const watcher = await watchPath('/var/log', {}, () => {})
 
 watcher.dispose()
 ```
+
+## CLI
+
+It's possible to call `@atom/watcher` from the command-line, like this:
+
+```sh
+$ watcher /path/to/watch
+```
+
+Example:
+
+```
+created directory: /path/to/watch/foo
+deleted directory: /path/to/watch/foo
+```
+
+It can be useful for testing the watcher and to describe a scenario when reporting an issue.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+const path = require('path')
+const watcher = require('./index')
+
+function usage () {
+  console.log('Usage: watcher <pattern> [<pattern>...] [options]')
+  console.log('  -h, --help\tShow help')
+  console.log('  -v, --verbose\tMake output more verbose')
+}
+
+function start (dirs, verbose) {
+  const options = { recursive: true }
+
+  const eventCallback = events => {
+    for (const event of events) {
+      if (event.action === 'modified' && !verbose) {
+        return
+      } else if (event.action === 'renamed') {
+        console.log(
+          `${event.action} ${event.kind}: ${event.oldPath} → ${event.path}`
+        )
+      } else {
+        console.log(`${event.action} ${event.kind}: ${event.path}`)
+      }
+    }
+  }
+
+  for (const dir of dirs) {
+    watcher
+      .watchPath(dir, options, eventCallback)
+      .then(w => {
+        if (verbose) {
+          console.log('Watching', dir)
+        }
+        w.onDidError(err => console.error('Error:', err))
+      })
+      .catch(err => {
+        console.error('Error:', err)
+      })
+  }
+}
+
+function main (argv) {
+  const dirs = []
+  let verbose = false
+
+  argv.forEach((arg, i) => {
+    if (i === 0) {
+      return
+    }
+    if (i === 1 && path.basename(argv[0]) === 'node') {
+      return
+    }
+    if (arg === '-h' || arg === '--help') {
+      return usage()
+    } else if (arg === '-v' || arg === '--verbose') {
+      verbose = true
+    } else {
+      dirs.push(arg)
+    }
+  })
+
+  if (dirs.length === 0) {
+    return usage()
+  }
+
+  start(dirs, verbose)
+}
+
+main(process.argv)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.8",
   "description": "Atom filesystem watcher",
   "main": "lib/index.js",
+  "bin": "lib/cli.js",
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build",
     "publish": "node-pre-gyp package && node-pre-gyp-github publish --release",


### PR DESCRIPTION
### Description of the Change

The CLI can be used like this:

    $ watcher path/to/watch

### Alternate Designs

I've tried to do something simple, with no external dependencies. An alternative would be to copy [chokidar-cli](https://github.com/kimmobrunfeldt/chokidar-cli), with more options. But if we want to go in this direction, it'd better to do that outside of this repository, and in a new npm package.

### Benefits

It should help for testing @atom/watcher and reporting issues.

### Possible Drawbacks

It will be one more file in the npm package, and the script may have to be maintained in the future.

### Applicable Issues

N/A