### PR TITLE
Test with node 8 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- 7.9.0
+- 8
 - 10
 sudo: false
 dist: trusty

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Installation
 
-@atom/watcher is developed against Node.js 7.4.0 with the `--harmony` flag enabled, but it should work with any Node.js version that supports `async`/`await`. Your system must be able to [build native Node.js modules](https://github.com/nodejs/node-gyp#installation). @atom/watcher supports [MacOS](./docs/macos.md) _(>= MacOS 10.7)_, [Windows](./docs/windows.md) _(>= Windows XP, >= Windows Server 2003)_, and [Linux](./docs/linux.md) _(kernel >= 2.6.27, glibc >= 2.9 :point_right: Ubuntu >= 10.04, Debian >= 6, RHEL >= 6)_.
+@atom/watcher is developed against Node.js 8, but it should work with any Node.js version that supports `async`/`await`. Your system must be able to [build native Node.js modules](https://github.com/nodejs/node-gyp#installation). @atom/watcher supports [MacOS](./docs/macos.md) _(>= MacOS 10.7)_, [Windows](./docs/windows.md) _(>= Windows XP, >= Windows Server 2003)_, and [Linux](./docs/linux.md) _(kernel >= 2.6.27, glibc >= 2.9 :point_right: Ubuntu >= 10.04, Debian >= 6, RHEL >= 6)_.
 
 ```bash
 $ npm install @atom/watcher


### PR DESCRIPTION
### Description of the Change

Test with node 8 instead of node 7 on travis. I think that atom comes with electron 2.0 now, and it is a node 8 that is packaged with it, so it'd be safer to also test with node 8 on travis.
