### PR TITLE
Revert "Defer worker start"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@atom/watcher",
-  "version": "1.3.0",
+  "version": "1.3.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atom/watcher",
-  "version": "1.3.0",
+  "version": "1.3.1-0",
   "description": "Atom filesystem watcher",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -123,7 +123,7 @@ void configure(const Nan::FunctionCallbackInfo<Value> &info)
   }
 
   all->set_result(move(r));
-  all->mark_ready();
+  all->fire_if_empty(true);
 }
 
 void watch(const Nan::FunctionCallbackInfo<Value> &info)

--- a/src/hub.cpp
+++ b/src/hub.cpp
@@ -60,6 +60,7 @@ Hub::Hub() :
     report_uv_error(err);
   }
 
+  report_if_error(worker_thread.run());
   freeze();
 }
 
@@ -91,13 +92,13 @@ Result<> Hub::unwatch(ChannelID channel_id, unique_ptr<AsyncCallback> &&ack_call
 
   string root;
   shared_ptr<AllCallback> all = AllCallback::create(move(ack_callback));
-  unique_ptr<AsyncCallback> worker_cb = all->create_callback("@atom/watcher:hub.unwatch.worker");
-  unique_ptr<AsyncCallback> polling_cb = all->create_callback("@atom/worker:hub.unwatch.polling");
 
   Result<> r = ok_result();
-  r &= send_command(worker_thread, CommandPayloadBuilder::remove(channel_id), move(worker_cb));
-  r &= send_command(polling_thread, CommandPayloadBuilder::remove(channel_id), move(polling_cb));
-  all->mark_ready();
+  r &= send_command(
+    worker_thread, CommandPayloadBuilder::remove(channel_id), all->create_callback("@atom/watcher:hub.unwatch.worker"));
+  r &= send_command(polling_thread,
+    CommandPayloadBuilder::remove(channel_id),
+    all->create_callback("@atom/worker:hub.unwatch.polling"));
 
   auto maybe_event_callback = channel_callbacks.find(channel_id);
   if (maybe_event_callback == channel_callbacks.end()) {

--- a/src/nan/all_callback.cpp
+++ b/src/nan/all_callback.cpp
@@ -34,7 +34,6 @@ shared_ptr<AllCallback> AllCallback::create(unique_ptr<AsyncCallback> &&done)
 
 AllCallback::AllCallback(unique_ptr<AsyncCallback> &&done) :
   done(move(done)),
-  ready{false},
   fired{false},
   total{0},
   remaining{0},
@@ -56,12 +55,6 @@ unique_ptr<AsyncCallback> AllCallback::create_callback(const char *async_name)
   return fn_callback(async_name, functions.front());
 }
 
-void AllCallback::mark_ready()
-{
-  ready = true;
-  fire_if_empty(true);
-}
-
 void AllCallback::set_result(Result<> &&r)
 {
   if (r.is_ok()) return;
@@ -77,7 +70,6 @@ void AllCallback::set_result(Result<> &&r)
 void AllCallback::fire_if_empty(bool sync)
 {
   if (remaining > 0) return;
-  if (!ready) return;
   if (fired) return;
   fired = true;
 

--- a/src/nan/all_callback.h
+++ b/src/nan/all_callback.h
@@ -21,8 +21,6 @@ public:
 
   std::unique_ptr<AsyncCallback> create_callback(const char *async_name);
 
-  void mark_ready();
-
   void set_result(Result<> &&r);
 
   void fire_if_empty(bool sync);
@@ -38,7 +36,6 @@ private:
   void callback_complete(size_t callback_index, const Nan::FunctionCallbackInfo<v8::Value> &info);
 
   std::unique_ptr<AsyncCallback> done;
-  bool ready;
   bool fired;
   size_t total;
   size_t remaining;

--- a/src/worker/worker_thread.cpp
+++ b/src/worker/worker_thread.cpp
@@ -42,26 +42,6 @@ Result<> WorkerThread::body()
   return platform->listen();
 }
 
-Result<Thread::OfflineCommandOutcome> WorkerThread::handle_offline_command(const CommandPayload *payload)
-{
-  Result<OfflineCommandOutcome> r = Thread::handle_offline_command(payload);
-  if (r.is_error()) return r;
-
-  if (payload->get_action() == COMMAND_ADD) {
-    return ok_result(TRIGGER_RUN);
-  }
-
-  if (payload->get_action() == COMMAND_CACHE_SIZE) {
-    handle_cache_size_command(payload);
-  }
-
-  if (payload->get_action() == COMMAND_STATUS) {
-    handle_status_command(payload);
-  }
-
-  return ok_result(OFFLINE_ACK);
-}
-
 Result<Thread::CommandOutcome> WorkerThread::handle_add_command(const CommandPayload *payload)
 {
   Result<bool> r = platform->handle_add_command(

--- a/src/worker/worker_thread.h
+++ b/src/worker/worker_thread.h
@@ -30,8 +30,6 @@ private:
 
   Result<> body() override;
 
-  Result<OfflineCommandOutcome> handle_offline_command(const CommandPayload *payload) override;
-
   Result<CommandOutcome> handle_add_command(const CommandPayload *payload) override;
 
   Result<CommandOutcome> handle_remove_command(const CommandPayload *payload) override;

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -29,29 +29,19 @@ describe('configuration', function () {
     assert.match(contents, /FileLogger opened/)
   })
 
+  it('configures the worker thread logger', async function () {
+    await configure({ workerLog: fixture.workerLogFile })
+
+    const contents = await fs.readFile(fixture.workerLogFile)
+    assert.match(contents, /FileLogger opened/)
+  })
+
   it('fails if the main log file cannot be written', async function () {
     await assert.isRejected(configure({ mainLog: badPath }), /No such file or directory/)
   })
 
-  describe('for the worker thread', function () {
-    // There's currently no way to *stop* the worker thread, so we can't reliably test it in the stopped state.
-
-    describe("after it's started", function () {
-      it('configures the logger', async function () {
-        await fixture.watch([], { poll: false }, () => {})
-
-        await configure({ workerLog: fixture.workerLogFile })
-
-        const contents = await fs.readFile(fixture.workerLogFile)
-        assert.match(contents, /FileLogger opened/)
-      })
-
-      it('fails if the worker log file cannot be written', async function () {
-        await fixture.watch([], { poll: false }, () => {})
-
-        await assert.isRejected(configure({ workerLog: badPath }), /No such file or directory/)
-      })
-    })
+  it('fails if the worker log file cannot be written', async function () {
+    await assert.isRejected(configure({ workerLog: badPath }), /No such file or directory/)
   })
 
   describe('for the polling thread', function () {


### PR DESCRIPTION
#201 is what ultimately fixed the prebuild hang issue. I'm getting some test failures and renderer crashes on atom/atom#17899 with 1.3.0, and this is the riskiest change that went in to that release, so I'm going to revert and see if that improves things.

Reverts atom/watcher#200.