### PR TITLE
Update syntax to build against electron v7.3.2

### DIFF
--- a/src/hub.cpp
+++ b/src/hub.cpp
@@ -211,13 +211,18 @@ void Hub::handle_events_from(Thread &thread)
       ChannelID channel_id = fs->get_channel_id();
 
       Local<Object> js_event = Nan::New<Object>();
-      js_event->Set(
-        Nan::New<String>("action").ToLocalChecked(), Nan::New<Number>(static_cast<int>(fs->get_filesystem_action())));
-      js_event->Set(
-        Nan::New<String>("kind").ToLocalChecked(), Nan::New<Number>(static_cast<int>(fs->get_entry_kind())));
-      js_event->Set(
-        Nan::New<String>("oldPath").ToLocalChecked(), Nan::New<String>(fs->get_old_path()).ToLocalChecked());
-      js_event->Set(Nan::New<String>("path").ToLocalChecked(), Nan::New<String>(fs->get_path()).ToLocalChecked());
+      js_event->Set(Nan::GetCurrentContext(),
+        Nan::New<String>("action").ToLocalChecked(),
+        Nan::New<Number>(static_cast<int>(fs->get_filesystem_action())));
+      js_event->Set(Nan::GetCurrentContext(),
+        Nan::New<String>("kind").ToLocalChecked(),
+        Nan::New<Number>(static_cast<int>(fs->get_entry_kind())));
+      js_event->Set(Nan::GetCurrentContext(),
+        Nan::New<String>("oldPath").ToLocalChecked(),
+        Nan::New<String>(fs->get_old_path()).ToLocalChecked());
+      js_event->Set(Nan::GetCurrentContext(),
+        Nan::New<String>("path").ToLocalChecked(),
+        Nan::New<String>(fs->get_path()).ToLocalChecked());
 
       to_deliver[channel_id].push_back(js_event);
       continue;
@@ -311,7 +316,7 @@ void Hub::handle_events_from(Thread &thread)
 
     int index = 0;
     for (auto &js_event : js_events) {
-      js_array->Set(index, js_event);
+      js_array->Set(Nan::GetCurrentContext(), index, js_event);
       index++;
     }
 


### PR DESCRIPTION
### Description of the Change

Electron 7.3.2 brings in NodeJS v12.8.1 which requires to update some
`Nan` function calls.

We now pass the current `Local<Context>` to `Object->Set()` calls and
all methods extending it.

### Benefits

Atom/Watcher can now be built against electron v7.3.2.
